### PR TITLE
[Feature #21] Implementation of spif:parseDate

### DIFF
--- a/s-pipes-core/src/main/java/cz/cvut/spipes/exception/ParseException.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/exception/ParseException.java
@@ -1,0 +1,8 @@
+package cz.cvut.spipes.exception;
+
+public class ParseException extends RuntimeException {
+
+    public ParseException() {
+        super("Could not parse input string");
+    }
+}

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/function/spif/ParseDate.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/function/spif/ParseDate.java
@@ -1,17 +1,26 @@
 package cz.cvut.spipes.function.spif;
 
 import cz.cvut.spipes.constants.SPIF;
+import cz.cvut.spipes.exception.ParseException;
 import cz.cvut.spipes.function.ValueFunction;
+import org.apache.jena.datatypes.RDFDatatype;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.expr.NodeValue;
 import org.apache.jena.sparql.function.FunctionEnv;
 import org.topbraid.spin.arq.AbstractFunction3;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
+/**
+ * Converts a string in a semi-structured format into a xsd:date, xsd:dateTime or xsd:time literal.
+ * The input string must be in a given template format, e.g. \"dd.MM.yyyy\" for strings such as 4.2.2022."
+ */
 public class ParseDate extends AbstractFunction3 implements ValueFunction {
-
 
     private static final String TYPE_IRI = SPIF.getURI() + "parseDate";
 
@@ -21,15 +30,46 @@ public class ParseDate extends AbstractFunction3 implements ValueFunction {
     }
 
     @Override
-    protected NodeValue exec(Node text, Node pattern, Node patternLanguage, FunctionEnv env) {
+    public NodeValue exec(Node text, Node pattern, Node patternLanguage, FunctionEnv env) {
 
+        String textValue = text.getLiteralValue().toString();
+        String patternValue = pattern.getLiteralValue().toString();
+        String patternLanguageValue = patternLanguage.getLiteralValue().toString();
+        Locale locale = new Locale(patternLanguageValue);
 
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern.getLiteralValue().toString());
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(patternValue).withLocale(locale);
 
-        LocalDate date
-            = LocalDate.parse(text.getLiteralValue().toString(), formatter);
+        try{
+            LocalDateTime localDateTime = LocalDateTime.parse(textValue,formatter);
+            return getDateTimeNode(String.valueOf(localDateTime));
+        }catch(Exception ignored){}
 
+        try{
+            LocalDate localDate = LocalDate.parse(textValue,formatter);
+            return getDateNode(String.valueOf(localDate));
+        }catch(Exception ignored){}
 
-        return null;
+        try{
+            LocalTime localTime = LocalTime.parse(textValue,formatter);
+            return getTimeNode(String.valueOf(localTime));
+        }catch(Exception e){
+            throw new ParseException();
+        }
+    }
+
+    private NodeValue getDateNode(String date){
+        return getNode(date, XSDDatatype.XSDdate);
+    }
+    private NodeValue getTimeNode(String date){
+        return getNode(date, XSDDatatype.XSDtime);
+    }
+    private NodeValue getDateTimeNode(String date){return getNode(date, XSDDatatype.XSDdateTime);}
+
+    private NodeValue getNode(String date,XSDDatatype type) {
+        return NodeValue.makeNode(
+                date,
+                null,
+                ((RDFDatatype) type).getURI()
+        );
     }
 }

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/function/spif/ParseDate.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/function/spif/ParseDate.java
@@ -41,13 +41,8 @@ public class ParseDate extends AbstractFunction3 implements ValueFunction {
      */
     @Override
     public NodeValue exec(Node text, Node pattern, Node patternLanguage, FunctionEnv env) {
-        String textValue, patternValue;
-        try{
-            textValue = text.getLiteralValue().toString();
-            patternValue = pattern.getLiteralValue().toString();
-        }catch(Exception e){
-            throw new IllegalArgumentException("Some of required parameters were not provided.");
-        }
+        String textValue = getRequiredParameterLiteralValue(text, 1);
+        String patternValue = getRequiredParameterLiteralValue(pattern, 2);
 
         Optional<Node> patternLanguageNode = Optional.ofNullable(patternLanguage);
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(patternValue);
@@ -68,6 +63,16 @@ public class ParseDate extends AbstractFunction3 implements ValueFunction {
             return getTimeNode(localTime.format(DateTimeFormatter.ofPattern("kk:mm:ss")));
         }catch(Exception e){
             throw new ParseException();
+        }
+    }
+
+    private String getRequiredParameterLiteralValue(Node text, int number) {
+        if(text == null){
+            throw new IllegalArgumentException(number + ". argument of this function is required but missing.");
+        }else if(text.isLiteral()){
+            return text.getLiteralValue().toString();
+        }else{
+            throw new IllegalArgumentException(number + ". argument of this function is not literal.");
         }
     }
 

--- a/s-pipes-core/src/test/java/cz/cvut/spipes/function/date/ParseDateTest.java
+++ b/s-pipes-core/src/test/java/cz/cvut/spipes/function/date/ParseDateTest.java
@@ -22,9 +22,9 @@ public class ParseDateTest {
     @Test
     public void execReturnsDate_ItalianLocale() {
         ParseDate parseDate = new ParseDate();
-        Node text = createLiteral("02.11.2021");
-        Node pattern = createLiteral("dd.MM.yyyy");
-        Node patternLanguage = createLiteral("de");
+        Node text = createLiteral("02/11/21");
+        Node pattern = createLiteral("dd/MM/yy");
+        Node patternLanguage = createLiteral("it");
 
         NodeValue returnedDate = parseDate.exec(text, pattern, patternLanguage, null);
         NodeValue expectedDate = getDateNode("2021-11-02");
@@ -34,9 +34,9 @@ public class ParseDateTest {
     @Test
     public void execReturnsDate_EnglishLocale() {
         ParseDate parseDate = new ParseDate();
-        Node text = createLiteral("2010-09-21");
-        Node pattern = createLiteral("yyyy-MM-dd");
-        Node patternLanguage = createLiteral("de");
+        Node text = createLiteral("9/21/10");
+        Node pattern = createLiteral("M/dd/yy");
+        Node patternLanguage = createLiteral("en");
 
         NodeValue returnedDate = parseDate.exec(text, pattern, patternLanguage, null);
         NodeValue expectedDate = getDateNode("2010-09-21");
@@ -48,7 +48,7 @@ public class ParseDateTest {
         ParseDate parseDate = new ParseDate();
         Node text = createLiteral("19/12/2016");
         Node pattern = createLiteral("dd/MM/yyyy");
-        Node patternLanguage = createLiteral("de");
+        Node patternLanguage = createLiteral("fr");
 
         NodeValue returnedDate = parseDate.exec(text, pattern, patternLanguage, null);
         NodeValue expectedDate = getDateNode("2016-12-19");
@@ -56,63 +56,114 @@ public class ParseDateTest {
     }
 
     @Test
-    public void execReturnsTimeWithSeconds() {
+    public void execReturnsTime_WithSeconds() {
         ParseDate parseDate = new ParseDate();
         Node text = createLiteral("09:10:10");
         Node pattern = createLiteral("k:m:s");
-        Node patternLanguage = createLiteral("de");
-        NodeValue returnedDate = parseDate.exec(text, pattern, patternLanguage, null);
+        NodeValue returnedTime = parseDate.exec(text, pattern, null, null);
 
-        NodeValue expectedDate = getTimeNode("09:10:10");
-        assertEquals(expectedDate, returnedDate);
+        NodeValue expectedTime = getTimeNode("09:10:10");
+        assertEquals(expectedTime, returnedTime);
     }
 
     @Test
-    public void execReturnsTimeWithoutSeconds() {
+    public void execReturnsTime_WithoutSeconds() {
         ParseDate parseDate = new ParseDate();
         Node text = createLiteral("23:59");
         Node pattern = createLiteral("k:m");
-        Node patternLanguage = createLiteral("de");
-        NodeValue returnedDate = parseDate.exec(text, pattern, patternLanguage, null);
 
-        NodeValue expectedDate = getTimeNode("23:59");
-        assertEquals(expectedDate, returnedDate);
+        NodeValue returnedTime = parseDate.exec(text, pattern, null, null);
+        NodeValue expectedTime = getTimeNode("23:59:00");
+
+        assertEquals(expectedTime, returnedTime);
     }
 
     @Test
-    public void execReturnsDateTime() {
+    public void execReturnsTime_OnlyHours() {
         ParseDate parseDate = new ParseDate();
-        Node text = createLiteral("2001.07.04 12:08:56");
+        Node text = createLiteral("15");
+        Node pattern = createLiteral("k");
+
+        NodeValue returnedTime = parseDate.exec(text, pattern, null, null);
+        NodeValue expectedTime = getTimeNode("15:00:00");
+
+        assertEquals(expectedTime, returnedTime);
+    }
+
+
+    @Test
+    public void execReturnsDateTime_FrenchLocale() {
+        ParseDate parseDate = new ParseDate();
+        Node text = createLiteral("19/12/2016 12:08:56");
+        Node pattern = createLiteral("dd/MM/yyyy HH:mm:ss");
+        Node patternLanguage = createLiteral("fr");
+
+        NodeValue returnedDateTime = parseDate.exec(text, pattern, patternLanguage, null);
+        NodeValue expectedDateTime = getDateTimeNode("2016-12-19T12:08:56");
+
+        assertEquals(expectedDateTime, returnedDateTime);
+    }
+
+    @Test
+    public void execReturnsDateTime_complexPattern() {
+        ParseDate parseDate = new ParseDate();
+        Node text = createLiteral("2001.07.04 at 12:08:56 PDT");
+        Node pattern = createLiteral("yyyy.MM.dd 'at' HH:mm:ss z");
+
+        NodeValue returnedDateTime = parseDate.exec(text, pattern, null, null);
+        NodeValue expectedDateTime = getDateTimeNode("2001-07-04T12:08:56");
+
+        assertEquals(expectedDateTime, returnedDateTime);
+    }
+
+    @Test
+    public void execReturnsDateTime_nullPatternLanguage() {
+        ParseDate parseDate = new ParseDate();
+        Node text = createLiteral("2022.01.01 23:59:59");
         Node pattern = createLiteral("yyyy.MM.dd HH:mm:ss");
-        Node patternLanguage = createLiteral("en");
-        NodeValue returnedDate = parseDate.exec(text, pattern, patternLanguage, null);
 
-        NodeValue expectedDate = getDateTimeNode("2001-07-04T12:08:56");
-        assertEquals(expectedDate, returnedDate);
-    }
+        NodeValue returnedDateTime = parseDate.exec(text, pattern, null, null);
+        NodeValue expectedDateTime = getDateTimeNode("2022-01-01T23:59:59");
 
-    @Test
-    public void execReturnsDateTxime() {
-        ParseDate parseDate = new ParseDate();
-        Node text = createLiteral("2001.07.04 AD 12:08:56 PDT");
-        Node pattern = createLiteral("yyyy.MM.dd G HH:mm:ss z");
-        Node patternLanguage = createLiteral("dxxxe");
-        NodeValue returnedDate = parseDate.exec(text, pattern, patternLanguage, null);
-
-        NodeValue expectedDate = getDateTimeNode("2001-07-04T12:08:56");
-        assertEquals(expectedDate, returnedDate);
+        assertEquals(expectedDateTime, returnedDateTime);
     }
 
 
     @Test
     public void execThrowsException_badInput() {
         ParseDate parseDate = new ParseDate();
-        Node text = createLiteral("2001.07.04 12:08:56exception");
-        Node pattern = createLiteral("yyyy.MM.dd HH:mm:ss");
-        Node patternLanguage = createLiteral("de");
+        Node text = createLiteral("Lorem Ipsum");
+        Node pattern = createLiteral("yyyy.MM.dd");
 
-        assertThrows(ParseException.class, () -> parseDate.exec(text, pattern, patternLanguage, null));
+        assertThrows(ParseException.class, () -> parseDate.exec(text, pattern, null, null));
     }
+
+    @Test
+    public void execThrowsException_nullInputText() {
+        ParseDate parseDate = new ParseDate();
+        Node pattern = createLiteral("yyyy.MM.dd");
+
+        assertThrows(IllegalArgumentException.class, () -> parseDate.exec(null, pattern, null, null));
+    }
+
+    @Test
+    public void execThrowsException_nullPattern() {
+        ParseDate parseDate = new ParseDate();
+        Node text = createLiteral("21/10/2013");
+
+        assertThrows(IllegalArgumentException.class, () -> parseDate.exec(text, null, null, null));
+    }
+
+    @Test
+    public void execThrowsException_badPatternLanguage() {
+        ParseDate parseDate = new ParseDate();
+        Node text = createLiteral("19/12/2016");
+        Node pattern = createLiteral("dd/MM/yyyy");
+        Node patternLanguage = createLiteral("en");
+
+        assertThrows(IllegalArgumentException.class, () -> parseDate.exec(text, pattern, patternLanguage, null));
+    }
+
 
     private NodeValue getDateNode(String date){
         return getNode(date, XSDDatatype.XSDdate);

--- a/s-pipes-core/src/test/java/cz/cvut/spipes/function/date/ParseDateTest.java
+++ b/s-pipes-core/src/test/java/cz/cvut/spipes/function/date/ParseDateTest.java
@@ -6,18 +6,13 @@ import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.expr.NodeValue;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.ExpectedException;
 
-import static org.apache.jena.graph.NodeFactory.createLiteral;
+import static org.apache.jena.graph.NodeFactory.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ParseDateTest {
-
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
 
     @Test
     public void execReturnsDate_ItalianLocale() {
@@ -151,7 +146,13 @@ public class ParseDateTest {
         ParseDate parseDate = new ParseDate();
         Node text = createLiteral("21/10/2013");
 
-        assertThrows(IllegalArgumentException.class, () -> parseDate.exec(text, null, null, null));
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> parseDate.exec(text, null, null, null)
+        );
+
+        String expectedMessage = "2. argument of this function is required but missing.";
+        assertEquals(expectedMessage, exception.getMessage());
     }
 
     @Test
@@ -161,7 +162,43 @@ public class ParseDateTest {
         Node pattern = createLiteral("dd/MM/yyyy");
         Node patternLanguage = createLiteral("en");
 
-        assertThrows(IllegalArgumentException.class, () -> parseDate.exec(text, pattern, patternLanguage, null));
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> parseDate.exec(text, pattern, patternLanguage, null)
+        );
+
+        String expectedMessage = "Pattern does not corresponds to the pattern language.";
+        assertEquals(expectedMessage, exception.getMessage());
+    }
+
+    @Test
+    public void execReturnsDate_uriNode() {
+        ParseDate parseDate = new ParseDate();
+        Node text = createLiteral("19/12/2016");
+        Node pattern = createURI("htttp://example.org/person");
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> parseDate.exec(text, pattern, null, null)
+        );
+
+        String expectedMessage = "2. argument of this function is not literal.";
+        assertEquals(expectedMessage, exception.getMessage());
+    }
+
+    @Test
+    public void execReturnsDate_blankNode() {
+        ParseDate parseDate = new ParseDate();
+        Node text = createBlankNode("blank node");
+        Node pattern = createLiteral("dd/MM/yy");
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> parseDate.exec(text, pattern, null, null)
+        );
+
+        String expectedMessage = "1. argument of this function is not literal.";
+        assertEquals(expectedMessage, exception.getMessage());
     }
 
 

--- a/s-pipes-core/src/test/java/cz/cvut/spipes/function/date/ParseDateTest.java
+++ b/s-pipes-core/src/test/java/cz/cvut/spipes/function/date/ParseDateTest.java
@@ -1,0 +1,134 @@
+package cz.cvut.spipes.function.date;
+
+import cz.cvut.spipes.exception.ParseException;
+import cz.cvut.spipes.function.spif.ParseDate;
+import org.apache.jena.datatypes.RDFDatatype;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.expr.NodeValue;
+import org.junit.Rule;
+import org.junit.jupiter.api.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.apache.jena.graph.NodeFactory.createLiteral;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ParseDateTest {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void execReturnsDate_ItalianLocale() {
+        ParseDate parseDate = new ParseDate();
+        Node text = createLiteral("02.11.2021");
+        Node pattern = createLiteral("dd.MM.yyyy");
+        Node patternLanguage = createLiteral("de");
+
+        NodeValue returnedDate = parseDate.exec(text, pattern, patternLanguage, null);
+        NodeValue expectedDate = getDateNode("2021-11-02");
+        assertEquals(expectedDate, returnedDate);
+    }
+
+    @Test
+    public void execReturnsDate_EnglishLocale() {
+        ParseDate parseDate = new ParseDate();
+        Node text = createLiteral("2010-09-21");
+        Node pattern = createLiteral("yyyy-MM-dd");
+        Node patternLanguage = createLiteral("de");
+
+        NodeValue returnedDate = parseDate.exec(text, pattern, patternLanguage, null);
+        NodeValue expectedDate = getDateNode("2010-09-21");
+        assertEquals(expectedDate, returnedDate);
+    }
+
+    @Test
+    public void execReturnsDate_FrenchLocale() {
+        ParseDate parseDate = new ParseDate();
+        Node text = createLiteral("19/12/2016");
+        Node pattern = createLiteral("dd/MM/yyyy");
+        Node patternLanguage = createLiteral("de");
+
+        NodeValue returnedDate = parseDate.exec(text, pattern, patternLanguage, null);
+        NodeValue expectedDate = getDateNode("2016-12-19");
+        assertEquals(expectedDate, returnedDate);
+    }
+
+    @Test
+    public void execReturnsTimeWithSeconds() {
+        ParseDate parseDate = new ParseDate();
+        Node text = createLiteral("09:10:10");
+        Node pattern = createLiteral("k:m:s");
+        Node patternLanguage = createLiteral("de");
+        NodeValue returnedDate = parseDate.exec(text, pattern, patternLanguage, null);
+
+        NodeValue expectedDate = getTimeNode("09:10:10");
+        assertEquals(expectedDate, returnedDate);
+    }
+
+    @Test
+    public void execReturnsTimeWithoutSeconds() {
+        ParseDate parseDate = new ParseDate();
+        Node text = createLiteral("23:59");
+        Node pattern = createLiteral("k:m");
+        Node patternLanguage = createLiteral("de");
+        NodeValue returnedDate = parseDate.exec(text, pattern, patternLanguage, null);
+
+        NodeValue expectedDate = getTimeNode("23:59");
+        assertEquals(expectedDate, returnedDate);
+    }
+
+    @Test
+    public void execReturnsDateTime() {
+        ParseDate parseDate = new ParseDate();
+        Node text = createLiteral("2001.07.04 12:08:56");
+        Node pattern = createLiteral("yyyy.MM.dd HH:mm:ss");
+        Node patternLanguage = createLiteral("en");
+        NodeValue returnedDate = parseDate.exec(text, pattern, patternLanguage, null);
+
+        NodeValue expectedDate = getDateTimeNode("2001-07-04T12:08:56");
+        assertEquals(expectedDate, returnedDate);
+    }
+
+    @Test
+    public void execReturnsDateTxime() {
+        ParseDate parseDate = new ParseDate();
+        Node text = createLiteral("2001.07.04 AD 12:08:56 PDT");
+        Node pattern = createLiteral("yyyy.MM.dd G HH:mm:ss z");
+        Node patternLanguage = createLiteral("dxxxe");
+        NodeValue returnedDate = parseDate.exec(text, pattern, patternLanguage, null);
+
+        NodeValue expectedDate = getDateTimeNode("2001-07-04T12:08:56");
+        assertEquals(expectedDate, returnedDate);
+    }
+
+
+    @Test
+    public void execThrowsException_badInput() {
+        ParseDate parseDate = new ParseDate();
+        Node text = createLiteral("2001.07.04 12:08:56exception");
+        Node pattern = createLiteral("yyyy.MM.dd HH:mm:ss");
+        Node patternLanguage = createLiteral("de");
+
+        assertThrows(ParseException.class, () -> parseDate.exec(text, pattern, patternLanguage, null));
+    }
+
+    private NodeValue getDateNode(String date){
+        return getNode(date, XSDDatatype.XSDdate);
+    }
+    private NodeValue getTimeNode(String time){
+        return getNode(time, XSDDatatype.XSDtime);
+    }
+    private NodeValue getDateTimeNode(String dateTime){
+        return getNode(dateTime, XSDDatatype.XSDdateTime);
+    }
+
+    private NodeValue getNode(String text, XSDDatatype type) {
+        return NodeValue.makeNode(
+                text,
+                null,
+                ((RDFDatatype) type).getURI()
+        );
+    }
+}


### PR DESCRIPTION
Implemented feature #21. 

Take a look at "execReturnsTime_WithoutSeconds" test, which is successful, but there's a warning. It happens when time has no second (e.g. "23:59" ), but it formats correctly to xsd:time.