### PR TITLE
[New] Enable getting username and password from config-core.properties

### DIFF
--- a/s-pipes-core/src/main/java/cz/cvut/spipes/util/CoreConfigProperies.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/util/CoreConfigProperies.java
@@ -11,6 +11,7 @@ public class CoreConfigProperies {
     private static final String CONFIG_FILE = "config-core.properties";
     private static final java.util.Properties prop = new java.util.Properties();
     private static final Logger LOG = LoggerFactory.getLogger(CoreConfigProperies.class);
+    private static final String variableAssignmentPrefix = "variable.assignment";
 
     static {
         try {
@@ -59,4 +60,7 @@ public class CoreConfigProperies {
         return System.getenv(name.toUpperCase().replaceAll("\\.", "_"));
     }
 
+    public static String getConfigurationVariable(String name) {
+        return get(variableAssignmentPrefix + "." + name);
+    }
 }

--- a/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jModule.java
+++ b/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jModule.java
@@ -3,9 +3,8 @@ package cz.cvut.spipes.modules;
 import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.engine.ExecutionContextFactory;
-import cz.cvut.spipes.engine.VariablesBinding;
+import cz.cvut.spipes.util.CoreConfigProperies;
 import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.riot.RDFLanguages;
 import org.eclipse.rdf4j.model.Resource;
@@ -58,6 +57,11 @@ public class Rdf4jModule extends AbstractModule {
     static final Property P_RDF4J_CONTEXT_IRI = getParameter("p-rdf4j-context-iri");
     private String rdf4jContextIRI;
 
+    static final Property P_RDF4J_REPOSITORY_USERNAME = getParameter("p-rdf4j-secured-username-variable");
+    private String rdf4jSecuredUsernameVariable;
+
+    static final Property P_RDF4J_REPOSITORY_PASSWORD = getParameter("p-rdf4j-secured-password-variable");
+    private String rdf4jSecuredPasswordVariable;
     /**
      * Whether the context should be replaced (true) or just enriched (false).
      */
@@ -105,17 +109,8 @@ public class Rdf4jModule extends AbstractModule {
             rdf4jServerURL,
             rdf4jRepositoryName);
 
-        VariablesBinding variablesBinding = getExecutionContext().getVariablesBinding();
-
-        String username = Optional
-                .ofNullable(variablesBinding.getNode("p-username"))
-                .map(RDFNode::toString)
-                .orElse(null);
-
-        String password = Optional
-                .ofNullable(variablesBinding.getNode("p-password"))
-                .map(RDFNode::toString)
-                .orElse(null);
+        String username = CoreConfigProperies.getConfigurationVariable(rdf4jSecuredUsernameVariable);
+        String password = CoreConfigProperies.getConfigurationVariable(rdf4jSecuredPasswordVariable);
 
         try {
             RepositoryManager repositoryManager = RepositoryProvider.getRepositoryManager(rdf4jServerURL);
@@ -187,6 +182,8 @@ public class Rdf4jModule extends AbstractModule {
             rdf4jContextIRI = getEffectiveValue(P_RDF4J_CONTEXT_IRI).asLiteral().getString();
         }
         isReplaceContext = this.getPropertyValue(P_IS_REPLACE_CONTEXT_IRI, false);
+        rdf4jSecuredUsernameVariable = getEffectiveValue(P_RDF4J_REPOSITORY_USERNAME).asLiteral().getString();
+        rdf4jSecuredPasswordVariable = getEffectiveValue(P_RDF4J_REPOSITORY_PASSWORD).asLiteral().getString();
     }
 
     private boolean isRdf4jContextIRIDefined() {


### PR DESCRIPTION
Related to #29.

This is the simple implementation as we discussed today -> read the username and password directly from config-core.properties