### PR TITLE
[FIX #193] Fix logging of execution in rdf4j repo

### DIFF
--- a/s-pipes-core/src/main/java/cz/cvut/spipes/logging/AdvancedLoggingProgressListener.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/logging/AdvancedLoggingProgressListener.java
@@ -12,6 +12,7 @@ import cz.cvut.spipes.model.SourceDatasetSnapshot;
 import cz.cvut.spipes.model.Thing;
 import cz.cvut.spipes.model.Transformation;
 import cz.cvut.spipes.modules.Module;
+import cz.cvut.spipes.util.DateUtils;
 import cz.cvut.spipes.util.Rdf4jUtils;
 import cz.cvut.spipes.util.TempFileUtils;
 import org.apache.jena.rdf.model.Model;
@@ -182,7 +183,7 @@ public class AdvancedLoggingProgressListener implements ProgressListener {
                 em.find(Transformation.class, pipelineExecutionIri, pd);
 
             // new
-            Date startDate = (Date) getSingletonPropertyValue(pipelineExecution, SPIPES.has_pipeline_execution_start_date);
+            Date startDate = DateUtils.toDate(getSingletonPropertyValue(pipelineExecution, SPIPES.has_pipeline_execution_start_date));
             addProperty(pipelineExecution, SPIPES.has_pipeline_execution_finish_date, finishDate);
             addProperty(pipelineExecution, SPIPES.has_pipeline_execution_finish_date_unix, finishDate.getTime());
             addProperty(pipelineExecution, SPIPES.has_pipeline_execution_duration, computeDuration(startDate, finishDate));

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/util/DateUtils.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/util/DateUtils.java
@@ -1,0 +1,22 @@
+package cz.cvut.spipes.util;
+
+import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.Objects;
+
+public class DateUtils {
+
+    public static Date toDate(Object objectDate){
+        Objects.requireNonNull(objectDate);
+
+        if(objectDate instanceof OffsetDateTime)
+            return toDate((OffsetDateTime)objectDate);
+        return (Date)objectDate;
+
+    }
+
+    public static Date toDate(OffsetDateTime objectDate) {
+        Objects.requireNonNull(objectDate);
+        return Date.from(objectDate.toInstant());
+    }
+}


### PR DESCRIPTION
- add DateUtils to handle conversion of different date classes to java.util.Date.