### PR TITLE
Issues/issue 199 executing module creator maven plugin

### DIFF
--- a/s-pipes-modules-utils/s-pipes-module-creator-maven-plugin/pom.xml
+++ b/s-pipes-modules-utils/s-pipes-module-creator-maven-plugin/pom.xml
@@ -24,15 +24,15 @@
             <version>3.6.3</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.6.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.6.0</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-project</artifactId>
-            <version>2.2.1</version>
         </dependency>
 
         <dependency>

--- a/s-pipes-modules-utils/s-pipes-module-creator-maven-plugin/src/main/java/RdfAnnotationProcessorMojo.java
+++ b/s-pipes-modules-utils/s-pipes-module-creator-maven-plugin/src/main/java/RdfAnnotationProcessorMojo.java
@@ -214,7 +214,7 @@ public class RdfAnnotationProcessorMojo extends AbstractMojo {
     }
 
     /**
-     * @implNote use of deprecated API to
+     * @implNote use of deprecated API to retrieve local repository instance
      * @param project
      * @return instance of local repository
      */

--- a/s-pipes-modules/pom.xml
+++ b/s-pipes-modules/pom.xml
@@ -51,24 +51,24 @@
                 </configuration>
             </plugin>
 
-<!--            <plugin>-->
-<!--                <groupId>cz.cvut.kbss</groupId>-->
-<!--                <artifactId>s-pipes-module-creator-maven-plugin</artifactId>-->
-<!--                <version>${project.parent.version}</version>-->
-<!--                <inherited>false</inherited>-->
-<!--                <executions>-->
-<!--                    <execution>-->
-<!--                        <goals>-->
-<!--                            <goal>process-annotations</goal>-->
-<!--                        </goals>-->
-<!--                        <configuration>-->
-<!--                            <mode>RDF_FOR_ALL_CHILDREN</mode>-->
-<!--                            <modulePackageName>cz.cvut.spipes</modulePackageName>-->
-<!--                            <ontologyFilename>all-modules.ttl</ontologyFilename>-->
-<!--                        </configuration>-->
-<!--                    </execution>-->
-<!--                </executions>-->
-<!--            </plugin>-->
+            <plugin>
+                <groupId>cz.cvut.kbss</groupId>
+                <artifactId>s-pipes-module-creator-maven-plugin</artifactId>
+                <version>${project.parent.version}</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>process-annotations</goal>
+                        </goals>
+                        <configuration>
+                            <mode>RDF_FOR_ALL_CHILDREN</mode>
+                            <modulePackageName>cz.cvut.spipes</modulePackageName>
+                            <ontologyFilename>all-modules.ttl</ontologyFilename>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
         </plugins>
     </build>


### PR DESCRIPTION
Issue #199 occurs when searching for field annotations in s-pipes module classes:
```
private List<cz.cvut.spipes.modules.Parameter> readConstraintsFromClass(Class<?> classObject) {
        return Arrays.stream(classObject.getDeclaredFields()).
        ...
}
```
The issue occurs when imported classes in an s-pipes module class cannot be found by the classloader which loaded it. 

For example, the class `org.supercsv.io.ICsvListReader` imported in module class `cz.cvut.spipes.modules.TabularModule` is not found by its class loader when processing field annotations.

This pull request resolves this issue by configuring the classloader used to load s-pipes module classes to include jars of direct dependencies see changes in `RdfAnnotationProcessorMojo.readAllModuleClasses`. Dependency  jars are fetched from the local maven repository.

Note that the local repository is retrieved using deprecated maven API `MavenProject.getProjectBuildingRequest`.