### PR TITLE
[#205] Fix declaring parameters from unrelated modules in RDF module descriptions.

### DIFF
--- a/s-pipes-modules/module-ckan2rdf/src/main/java/cz/cvut/spipes/modules/Ckan2RdfModule.java
+++ b/s-pipes-modules/module-ckan2rdf/src/main/java/cz/cvut/spipes/modules/Ckan2RdfModule.java
@@ -5,6 +5,7 @@ import cz.cvut.kbss.jopa.model.JOPAPersistenceProperties;
 import cz.cvut.kbss.jopa.model.descriptors.EntityDescriptor;
 import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.engine.ExecutionContext;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import eu.trentorise.opendata.jackan.CkanClient;
 import eu.trentorise.opendata.jackan.exceptions.CkanException;
 import eu.trentorise.opendata.jackan.model.CkanCatalog;
@@ -26,6 +27,7 @@ import org.apache.jena.vocabulary.RDF;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SPipesModule(label = "ckan2rdf-v1", comment = "Convert ckan to rdf.")
 public class Ckan2RdfModule extends AnnotatedAbstractModule {
 
     public static final String TYPE_URI = KBSS_MODULE.uri + "ckan2rdf-v1";

--- a/s-pipes-modules/module-ckan2rdf/src/main/java/cz/cvut/spipes/modules/SparqlEndpointDatasetExplorerModule.java
+++ b/s-pipes-modules/module-ckan2rdf/src/main/java/cz/cvut/spipes/modules/SparqlEndpointDatasetExplorerModule.java
@@ -5,6 +5,8 @@ import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.engine.ExecutionContextFactory;
 import java.time.Instant;
 import java.util.Calendar;
+
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.query.ParameterizedSparqlString;
 import org.apache.jena.query.Query;
@@ -18,6 +20,7 @@ import org.apache.jena.vocabulary.RDF;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SPipesModule(label = "sparqlEndpointDatasetExplorer-v1", comment = "TODO")
 public class SparqlEndpointDatasetExplorerModule extends AnnotatedAbstractModule {
 
     public static final String TYPE_URI = KBSS_MODULE.uri + "sparqlEndpointDatasetExplorer-v1";

--- a/s-pipes-modules/module-dataset-discovery/src/main/java/cz/cvut/spipes/modules/DatasetDiscoveryModule.java
+++ b/s-pipes-modules/module-dataset-discovery/src/main/java/cz/cvut/spipes/modules/DatasetDiscoveryModule.java
@@ -10,6 +10,8 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
+
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.query.QueryFactory;
@@ -24,6 +26,9 @@ import org.apache.jena.vocabulary.RDF;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SPipesModule(label = "dataset discovery v1", comment =
+        "Discovers dataset based on keyword userInput in repository linked.opendata.cz-federated-descriptor-faceted-search " +
+        "hosted at http://onto.fel.cvut.cz/rdf4j-server.")
 public class DatasetDiscoveryModule extends AbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(DatasetDiscoveryModule.class);
@@ -34,6 +39,7 @@ public class DatasetDiscoveryModule extends AbstractModule {
      * URL of the Sesame server.
      */
     private static final Property P_USER_INPUT = getParameter("prp-user-input");
+    @Parameter(urlPrefix = TYPE_URI, name = "prp-user-inpu")
     private String userInput;
 
     private static Property getParameter(final String name) {

--- a/s-pipes-modules/module-dataset-discovery/src/main/java/cz/cvut/spipes/modules/GetDatasetDescriptorsModule.java
+++ b/s-pipes-modules/module-dataset-discovery/src/main/java/cz/cvut/spipes/modules/GetDatasetDescriptorsModule.java
@@ -4,6 +4,9 @@ import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.engine.ExecutionContext;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Optional;
+
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
@@ -19,21 +22,27 @@ import org.apache.jena.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SPipesModule(label = "get dataset descriptors v1", comment = "Retrieve dataset descriptor for dataset with dataset-iri in endpoint-url.")
 public class GetDatasetDescriptorsModule extends AbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(GetDatasetDescriptorsModule.class);
 
     private static final String TYPE_URI = KBSS_MODULE.uri + "get-dataset-descriptors-v1";
+    private static final String PARAM_URI = TYPE_URI + "/";
 
     /**
      * URL of the Sesame server.
      */
     private static final Property P_DATASET_IRI = getParameter("p-dataset-iri");
+    private static final Property P_ENDPOINT_URL = getParameter("endpoint-url");
+
+    @Parameter(urlPrefix = PARAM_URI, name = "dataset-iri")
     private String prpDatasetIri;
 
     /**
      * URL of the SPARQL endpoint.
      */
+    @Parameter(urlPrefix = PARAM_URI, name = "endpoint-url")
     private String endpointUrl = "http://onto.fel.cvut.cz/rdf4j-server/repositories/descriptors-metadata";
 
     private static Property getParameter(final String name) {
@@ -95,5 +104,6 @@ public class GetDatasetDescriptorsModule extends AbstractModule {
     @Override
     public void loadConfiguration() {
         prpDatasetIri = this.getStringPropertyValue(P_DATASET_IRI);
+        endpointUrl = Optional.ofNullable(this.getStringPropertyValue(P_ENDPOINT_URL)).orElse(endpointUrl);
     }
 }

--- a/s-pipes-modules/module-eccairs/src/main/java/cz/cvut/spipes/modules/ImportE5XModule.java
+++ b/s-pipes-modules/module-eccairs/src/main/java/cz/cvut/spipes/modules/ImportE5XModule.java
@@ -15,6 +15,7 @@ import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.engine.ExecutionContextFactory;
 import cz.cvut.spipes.exception.ResourceNotFoundException;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import cz.cvut.spipes.modules.eccairs.EccairsAccessFactory;
 import cz.cvut.spipes.modules.eccairs.JopaPersistenceUtils;
 import cz.cvut.spipes.modules.eccairs.SesameDataDao;
@@ -34,9 +35,13 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
 
+@SPipesModule(label = "import-e5x", comment = "Convert e5x xml files to rdf.")
 public class ImportE5XModule extends AbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(ImportE5XModule.class);
+
+    @Parameter(name = "has-resource-uri")
+    private String e5xResourceUriStr;
 
     StreamResource e5xResource;
 
@@ -145,7 +150,7 @@ public class ImportE5XModule extends AbstractModule {
 
     @Override
     public void loadConfiguration() {
-        String e5xResourceUriStr = getEffectiveValue(KBSS_MODULE.has_resource_uri).asLiteral().toString();
+        e5xResourceUriStr = getEffectiveValue(KBSS_MODULE.has_resource_uri).asLiteral().toString();
         e5xResource = getResourceByUri(e5xResourceUriStr);
     }
 

--- a/s-pipes-modules/module-form/src/main/java/cz/cvut/spipes/modules/ConstructFormMetadataModule.java
+++ b/s-pipes-modules/module-form/src/main/java/cz/cvut/spipes/modules/ConstructFormMetadataModule.java
@@ -4,6 +4,7 @@ import cz.cvut.sforms.SFormsVocabularyJena;
 import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.constants.SML;
 import cz.cvut.spipes.engine.ExecutionContext;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.vocabulary.RDF;
@@ -21,6 +22,7 @@ import static cz.cvut.spipes.form.JenaFormUtils.getQuestionOrigin;
 /**
  * Compute form:has-origin-path and form:has-origin-path-id properties.
  */
+@SPipesModule(label = "construct form metadata", comment = "Compute form:has-origin-path and form:has-origin-path-id properties.")
 public class ConstructFormMetadataModule extends AnnotatedAbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConstructFormMetadataModule.class);

--- a/s-pipes-modules/module-form/src/main/java/cz/cvut/spipes/modules/ConstructTextualViewModule.java
+++ b/s-pipes-modules/module-form/src/main/java/cz/cvut/spipes/modules/ConstructTextualViewModule.java
@@ -12,6 +12,7 @@ import cz.cvut.spipes.constants.SML;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.form.JenaFormUtils;
 import cz.cvut.spipes.form.JopaPersistenceUtils;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
@@ -25,6 +26,10 @@ import java.util.function.Predicate;
  * For input Q&A models constructs textual view of specified questions. Each textual view represent the question
  * and its sub-questions recursively.
  */
+@SPipesModule(label = "construct textual view", comment =
+        "For input Q&A models constructs textual view of specified questions. Each textual" +
+        " view represent the question and its sub-questions recursively."
+)
 public class ConstructTextualViewModule extends AnnotatedAbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConstructTextualViewModule.class);

--- a/s-pipes-modules/module-form/src/main/java/cz/cvut/spipes/modules/FetchPossibleValuesModule.java
+++ b/s-pipes-modules/module-form/src/main/java/cz/cvut/spipes/modules/FetchPossibleValuesModule.java
@@ -6,6 +6,7 @@ import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.constants.SML;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.form.JenaFormUtils;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
@@ -19,6 +20,10 @@ import java.util.Map;
  * Inputs are forms using Q&A model. Possible values of questions are added to questions that does not have
  * any value attached and contains possible value query.
  */
+@SPipesModule(label = "fetch possible values", comment =
+        "Fetches possible values for answers of questions. Inputs are forms using Q&A model. Possible values of " +
+        "questions are added to questions that does not have any value attached and contains possible value query."
+)
 public class FetchPossibleValuesModule extends AnnotatedAbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(FetchPossibleValuesModule.class);

--- a/s-pipes-modules/module-form/src/main/java/cz/cvut/spipes/modules/MergeFormMetadataModule.java
+++ b/s-pipes-modules/module-form/src/main/java/cz/cvut/spipes/modules/MergeFormMetadataModule.java
@@ -6,6 +6,7 @@ import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.constants.SML;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.form.JenaFormUtils;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -20,6 +21,11 @@ import java.util.Random;
  * question origin combined with executionId. New question instances are created using questionInstanceTemplate
  * which defaults to "doc:question-{_questionOriginHash}-{_executionId}".
  */
+@SPipesModule(label = "merge form metadata", comment =
+        "Merges form metadata. Inputs are sample form and Q&A model. Questions from both models are remapped to new" +
+        "IRIs based on question origin combined with executionId. New question instances are created using" +
+        "questionInstanceTemplate which defaults to \"doc:question-{_questionOriginHash}-{_executionId}\"."
+)
 public class MergeFormMetadataModule extends AnnotatedAbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(MergeFormMetadataModule.class);

--- a/s-pipes-modules/module-identity/src/main/java/cz/cvut/spipes/modules/IdentityModule.java
+++ b/s-pipes-modules/module-identity/src/main/java/cz/cvut/spipes/modules/IdentityModule.java
@@ -2,9 +2,11 @@ package cz.cvut.spipes.modules;
 
 import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.engine.ExecutionContext;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SPipesModule(label = "identity", comment = "Implements a no-op.")
 public class IdentityModule extends AnnotatedAbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(IdentityModule.class);

--- a/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModule.java
+++ b/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModule.java
@@ -3,6 +3,7 @@ package cz.cvut.spipes.modules;
 import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.engine.ExecutionContextFactory;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import cz.cvut.spipes.sutime.AnnforModel;
 import cz.cvut.spipes.sutime.DescriptorModel;
 import edu.stanford.nlp.ling.CoreAnnotations;
@@ -27,13 +28,17 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 
+@SPipesModule(label = "temporal v0.1", comment = "Annotate temporal expressions in literals in input model.")
 public class SUTimeModule extends AbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(SUTimeModule.class);
 
     public static final String TYPE_URI = KBSS_MODULE.getURI() + "temporal-v0.1";
 
+    @Parameter(urlPrefix = DescriptorModel.prefix, name = "has-document-date")
     private List<Path> ruleFilePaths = new LinkedList<>();
+
+    @Parameter(urlPrefix = DescriptorModel.prefix, name = "has-rule-file")
     private String documentDate; // TODO support other formats ?
 
 

--- a/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModuleNew.java
+++ b/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModuleNew.java
@@ -3,6 +3,7 @@ package cz.cvut.spipes.modules;
 import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.constants.SML;
 import cz.cvut.spipes.engine.ExecutionContext;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import cz.cvut.spipes.sutime.AnnforModel;
 import cz.cvut.spipes.sutime.DescriptorModel;
 import cz.cvut.spipes.util.JenaUtils;
@@ -33,6 +34,7 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 
+@SPipesModule(label = "temporal-v1", comment = "Annotate temporal expressions in literals in input model.")
 public class SUTimeModuleNew extends AbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(SUTimeModuleNew.class);
@@ -43,16 +45,24 @@ public class SUTimeModuleNew extends AbstractModule {
     private static final String LIMIT_OFFSET_CLAUSE_MARKER_NAME = "LIMIT_OFFSET";
     private static final Property P_PAGE_SIZE = ResourceFactory.createProperty(TYPE_PREFIX + "page-size");
     private Integer pageSize = DEFAULT_PAGE_SIZE;
+
+    @Parameter(urlPrefix = SML.uri, name = "constructQuery")
     private List<Resource> constructQueries;
+
     //sml:replace
+    @Parameter(urlPrefix = SML.uri, name = "replace")
     private boolean isReplace;
 
     //kbss:parseText
     /**
      * Whether the query should be taken from sp:text property instead of from SPIN serialization
      */
+    @Parameter(name = "is-parse-text")
     private boolean parseText;
+
+    @Parameter(urlPrefix = DescriptorModel.prefix, name = "has-document-date")
     private List<Path> ruleFilePaths = new LinkedList<>();
+    @Parameter(urlPrefix = DescriptorModel.prefix, name = "has-rule-file")
     private String documentDate; // TODO support other formats ?
     private AnnotationPipeline pipeline;
 

--- a/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/sutime/DescriptorModel.java
+++ b/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/sutime/DescriptorModel.java
@@ -9,7 +9,7 @@ public class DescriptorModel {
     /**
      * The namespace of the vocabulary as a string
      */
-    private static final String prefix = "http://onto.fel.cvut.cz/ontologies/dataset-descriptor/temporal-v1/";
+    public static final String prefix = "http://onto.fel.cvut.cz/ontologies/dataset-descriptor/temporal-v1/";
 
     protected static final Resource resource(String local )
     { return ResourceFactory.createResource( prefix +  local ); }

--- a/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jCreateRepositoryModule.java
+++ b/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jCreateRepositoryModule.java
@@ -3,6 +3,7 @@ package cz.cvut.spipes.modules;
 import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.exceptions.RepositoryAlreadyExistsException;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
@@ -18,27 +19,33 @@ import java.util.Objects;
 /**
  * Module creates native store rdf4j repository on the given server with the given name
  */
+@SPipesModule(label = "rdf4j", comment = "Module creates native store rdf4j repository on the given server with the given name")
 public class Rdf4jCreateRepositoryModule extends AbstractModule {
-    private static final Logger LOG = LoggerFactory.getLogger(Rdf4jUpdateModule.class.getName());
-    private static final String TYPE_URI = KBSS_MODULE.getURI() + "rdf4j-create-repository";
-    private static final String PROPERTY_PREFIX_URI = KBSS_MODULE.getURI() + "rdf4j";
+    private static final Logger LOG = LoggerFactory.getLogger(Rdf4jCreateRepositoryModule.class.getName());
+    private static final String TYPE_URI = KBSS_MODULE.uri + "rdf4j-create-repository";
+    private static final String PROPERTY_PREFIX_URI = KBSS_MODULE.uri + "rdf4j";
 
     /**
      * URL of the Rdf4j server
      */
     static final Property P_RDF4J_SERVER_URL = getParameter("p-rdf4j-server-url");
+
+    @Parameter(urlPrefix = PROPERTY_PREFIX_URI + "rdf4j/", name = "p-rdf4j-server-url")
     private String rdf4jServerURL;
 
     /**
      * Rdf4j repository ID
      */
     static final Property P_RDF4J_REPOSITORY_NAME = getParameter("p-rdf4j-repository-name");
+    @Parameter(urlPrefix = PROPERTY_PREFIX_URI + "rdf4j/", name = "p-rdf4j-repository-name")
     private String rdf4jRepositoryName;
 
     /**
      * Don't try to create new repository if it already exists (Default value is false)
      */
     static final Property P_RDF4J_IGNORE_IF_EXISTS = getParameter("p-rdf4j-ignore-if-exists");
+
+    @Parameter(urlPrefix = PROPERTY_PREFIX_URI + "rdf4j/", name = "p-rdf4j-ignore-if-exists")
     private boolean rdf4jIgnoreIfExists;
 
     private RepositoryManager repositoryManager;

--- a/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jDeployModule.java
+++ b/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jDeployModule.java
@@ -4,6 +4,7 @@ import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.engine.ExecutionContextFactory;
 import cz.cvut.spipes.exception.ModuleConfigurationInconsistentException;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import cz.cvut.spipes.util.CoreConfigProperies;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -35,12 +36,16 @@ import java.util.Optional;
  * into default context of repository (if p-rdf4j-context-iri is not specified)
  * or concrete context (if p-rdf4j-context-iri is specified).
  */
+@SPipesModule(label = "deploy", comment =
+        "Module deploys content of input execution context into default context of repository (if p-rdf4j-context-iri " +
+        "is not specified) or concrete context (if p-rdf4j-context-iri is specified)."
+)
 public class Rdf4jDeployModule extends AbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(Rdf4jDeployModule.class);
 
-    private static String TYPE_URI = KBSS_MODULE.getURI()+"deploy";
-    private static String PROPERTY_PREFIX_URI = KBSS_MODULE.getURI()+"rdf4j";
+    private final static String TYPE_URI = KBSS_MODULE.uri + "deploy";
+    private final static String PROPERTY_PREFIX_URI = KBSS_MODULE.uri + "rdf4j";
 
     private static Property getParameter(final String name) {
         return ResourceFactory.createProperty(PROPERTY_PREFIX_URI + "/" + name);
@@ -50,21 +55,26 @@ public class Rdf4jDeployModule extends AbstractModule {
      * URL of the Rdf4j server
      */
     static final Property P_RDF4J_SERVER_URL = getParameter("p-rdf4j-server-url");
+    @Parameter(urlPrefix = PROPERTY_PREFIX_URI + "rdf4j/", name = "p-rdf4j-server-url")
     private String rdf4jServerURL;
 
     /**
      * Rdf4j repository ID
      */
     static final Property P_RDF4J_REPOSITORY_NAME = getParameter("p-rdf4j-repository-name");
+    @Parameter(urlPrefix = PROPERTY_PREFIX_URI + "rdf4j/", name = "p-rdf4j-repository-name")
+
     private String rdf4jRepositoryName;
 
     /**
      * IRI of the context that should be used for deployment
      */
     static final Property P_RDF4J_CONTEXT_IRI = getParameter("p-rdf4j-context-iri");
+    @Parameter(urlPrefix = PROPERTY_PREFIX_URI + "rdf4j/", name = "p-rdf4j-context-iri")
     private String rdf4jContextIRI;
 
     static final Property P_RDF4J_REPOSITORY_USERNAME = getParameter("p-rdf4j-secured-username-variable");
+    @Parameter(urlPrefix = PROPERTY_PREFIX_URI + "rdf4j/", name = "p-rdf4j-secured-username-variable")
     private String rdf4jSecuredUsernameVariable;
     private RepositoryManager repositoryManager;
     private Repository repository;

--- a/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jUpdateModule.java
+++ b/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jUpdateModule.java
@@ -5,6 +5,7 @@ import cz.cvut.spipes.constants.SML;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.exception.ModuleConfigurationInconsistentException;
 import cz.cvut.spipes.exceptions.RepositoryAccessException;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import cz.cvut.spipes.util.QueryUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
@@ -26,28 +27,35 @@ import org.topbraid.spin.vocabulary.SP;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@SPipesModule(label = "rdf4j update", comment = "Updates sparql endpoint configured in rdf4jServerURL using specified updateQueries.")
 public class Rdf4jUpdateModule extends AbstractModule {
     private static final Logger LOG = LoggerFactory.getLogger(Rdf4jUpdateModule.class.getName());
-    private static final String TYPE_URI = KBSS_MODULE.getURI() + "rdf4j-update";
-    private static final String PROPERTY_PREFIX_URI = KBSS_MODULE.getURI() + "rdf4j";
+    private static final String TYPE_URI = KBSS_MODULE.uri + "rdf4j-update";
+    private static final String PROPERTY_PREFIX_URI = KBSS_MODULE.uri + "rdf4j";
 
     /**
      * URL of the Rdf4j server
      */
     static final Property P_RDF4J_SERVER_URL = getParameter("p-rdf4j-server-url");
+    @Parameter(urlPrefix = PROPERTY_PREFIX_URI, name = "p-rdf4j-server-url")
     private String rdf4jServerURL;
 
     /**
      * Rdf4j repository ID
      */
     static final Property P_RDF4J_REPOSITORY_NAME = getParameter("p-rdf4j-repository-name");
+
+    @Parameter(urlPrefix = PROPERTY_PREFIX_URI, name = "p-rdf4j-repository-name")
     private String rdf4jRepositoryName;
     private List<String> updateQueries;
 
     static final Property P_RDF4J_STOP_ITERATION_ON_STABLE_TRIPLE_COUNT =
         getParameter("p-stop-iteration-on-stable-triple-count");
+
+    @Parameter(urlPrefix = PROPERTY_PREFIX_URI, name = "p-stop-iteration-on-stable-triple-count")
     private boolean onlyIfTripleCountChanges;
 
+    @Parameter(urlPrefix = PROPERTY_PREFIX_URI, name = "has-max-iteration-count")
     private int iterationCount;
 
     private Repository updateRepository;

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructAbstractModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructAbstractModule.java
@@ -3,6 +3,7 @@ package cz.cvut.spipes.modules;
 import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.constants.SML;
 import cz.cvut.spipes.engine.ExecutionContext;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import cz.cvut.spipes.util.JenaUtils;
 import cz.cvut.spipes.util.QueryUtils;
 import org.apache.jena.query.Query;
@@ -20,20 +21,25 @@ import org.topbraid.spin.vocabulary.SP;
 
 import java.util.List;
 
+@SPipesModule(label = "abstract apply construct", comment = "abstract module defining properties for subclasses of apply construct.")
 public abstract class ApplyConstructAbstractModule extends AnnotatedAbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(ApplyConstructAbstractModule.class);
-
+    private static final String TYPE_URI = KBSS_MODULE.uri + "abstract-apply-construct";
+    private static final String PROPERTY_PREFIX_URI = KBSS_MODULE.uri + "";
     //sml:constructQuery
+    @Parameter(urlPrefix = SML.uri, name = "constructQuery")
     protected List<Resource> constructQueries;
 
     //sml:replace
+    @Parameter(urlPrefix = SML.uri, name = "replace")
     protected boolean isReplace;
 
     //kbss:parseText
     /**
      * Whether the query should be taken from sp:text property instead of from SPIN serialization
      */
+    @Parameter(name = "is-parse-text")
     protected boolean parseText;
 
     //kbss:iterationCount
@@ -49,6 +55,7 @@ public abstract class ApplyConstructAbstractModule extends AnnotatedAbstractModu
      * <p>
      * Within each iteration, all queries are evaluated on the same model.
      */
+    @Parameter(name = "has-max-iteration-count")
     protected int iterationCount = -1;
 
 

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructV2Module.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructV2Module.java
@@ -1,17 +1,19 @@
 package cz.cvut.spipes.modules;
 
 import cz.cvut.spipes.constants.KBSS_MODULE;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * TODO Order of queries is not enforced.
  */
+@SPipesModule(label = "apply construct v2", comment = "Generates triples from input model using specified constructQueries.")
 public class ApplyConstructV2Module extends ApplyConstructAbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(ApplyConstructV2Module.class);
 
-    private static final String TYPE_URI = KBSS_MODULE.uri + "apply-contruct-v2";
+    private static final String TYPE_URI = KBSS_MODULE.uri + "apply-construct-v2";
 
     @Override
     public String getTypeURI() {

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithChunkedValuesAndScrollableCursorModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithChunkedValuesAndScrollableCursorModule.java
@@ -3,6 +3,7 @@ package cz.cvut.spipes.modules;
 import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.constants.SML;
 import cz.cvut.spipes.engine.VariablesBinding;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import cz.cvut.spipes.recursion.ChunkedValuesProvider;
 import cz.cvut.spipes.recursion.CombinedQueryTemplateRecursionProvider;
 import cz.cvut.spipes.recursion.QueryTemplateRecursionProvider;
@@ -26,6 +27,7 @@ import org.topbraid.spin.model.Select;
  * TODO issue with redundant call {@link ScrollableCursorProvider}
  * TODO supports only one CONSTRUCT query
  */
+@SPipesModule(label = "apply construct with chunked values and scrollable cursor", comment = "Apply construct with chunked values and scrollable cursor")
 public class ApplyConstructWithChunkedValuesAndScrollableCursorModule extends ApplyConstructAbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(ApplyConstructWithChunkedValuesAndScrollableCursorModule.class);
@@ -37,9 +39,13 @@ public class ApplyConstructWithChunkedValuesAndScrollableCursorModule extends Ap
     private static final Property P_CHUNK_SIZE = ResourceFactory.createProperty(TYPE_PREFIX + "chunk-size");
     private static final Property P_PAGE_SIZE = ResourceFactory.createProperty(TYPE_PREFIX + "page-size");
 
+    @Parameter(urlPrefix = TYPE_PREFIX, name = "chunk-size")
     private Integer chunkSize = DEFAULT_CHUNK_SIZE;
 
+    @Parameter(urlPrefix = TYPE_PREFIX, name = "page-size")
     private Integer pageSize = DEFAULT_PAGE_SIZE;
+
+    @Parameter(urlPrefix = SML.uri, name = "selectQuery")
     private Select selectQuery;
 
 

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithChunkedValuesModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithChunkedValuesModule.java
@@ -3,6 +3,7 @@ package cz.cvut.spipes.modules;
 import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.constants.SML;
 import cz.cvut.spipes.engine.VariablesBinding;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import cz.cvut.spipes.util.QueryUtils;
 import java.util.Objects;
 import org.apache.jena.query.Query;
@@ -22,6 +23,7 @@ import org.topbraid.spin.model.Select;
 /**
  * TODO Order of queries is not enforced.
  */
+@SPipesModule(label = "apply construct with chunked values", comment = "Apply construct with chunked values.")
 public class ApplyConstructWithChunkedValuesModule extends ApplyConstructAbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(ApplyConstructWithChunkedValuesModule.class);
@@ -32,7 +34,10 @@ public class ApplyConstructWithChunkedValuesModule extends ApplyConstructAbstrac
     private static final String VALUES_CLAUSE_MARKER_NAME = "VALUES";
     private static final Property P_CHUNK_SIZE = ResourceFactory.createProperty(TYPE_PREFIX + "chunk-size");
 
+    @Parameter(urlPrefix = TYPE_PREFIX, name = "chunk-size")
     private Integer chunkSize = DEFAULT_CHUNK_SIZE;
+
+    @Parameter(urlPrefix = SML.uri, name = "selectQuery")
     private Select selectQuery;
 
 

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithScrollableCursorModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithScrollableCursorModule.java
@@ -1,6 +1,7 @@
 package cz.cvut.spipes.modules;
 
 import cz.cvut.spipes.constants.KBSS_MODULE;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import cz.cvut.spipes.util.QueryUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
@@ -11,6 +12,7 @@ import org.slf4j.LoggerFactory;
 /**
  * TODO Order of queries is not enforced.
  */
+@SPipesModule(label = "apply construct with scrollable cursor", comment = "Apply construct with scrollable cursor.")
 public class ApplyConstructWithScrollableCursorModule extends ApplyConstructAbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(ApplyConstructWithScrollableCursorModule.class);
@@ -21,6 +23,7 @@ public class ApplyConstructWithScrollableCursorModule extends ApplyConstructAbst
     private static final String LIMIT_OFFSET_CLAUSE_MARKER_NAME = "LIMIT_OFFSET";
     private static final Property P_PAGE_SIZE = ResourceFactory.createProperty(TYPE_PREFIX + "page-size");
 
+    @Parameter(urlPrefix = TYPE_PREFIX, name = "page-size")
     private Integer pageSize = DEFAULT_PAGE_SIZE;
 
     @Override

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/DownloadGraphModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/DownloadGraphModule.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.riot.Lang;
@@ -17,6 +19,7 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SPipesModule(label = "sparql endpoint download graph", comment = "Downloads named graph namedGraphId from sparql endpoint endpointUrl.")
 public class DownloadGraphModule extends AnnotatedAbstractModule {
 
     private static final String TYPE_URI = KBSS_MODULE.uri + "sparql-endpoint-download-graph";

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ExternalSchemExModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ExternalSchemExModule.java
@@ -4,6 +4,7 @@ import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.constants.SML;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.engine.ExecutionContextFactory;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import cz.cvut.spipes.util.ExecUtils;
 import java.io.IOException;
 import java.io.InputStream;
@@ -13,6 +14,7 @@ import java.nio.file.Paths;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.util.FileUtils;
 
+@SPipesModule(label = "external schemex", comment = "external schemex")
 public class ExternalSchemExModule extends AbstractModule {
 
     private static final String MODULE_ID = "external-schemex";
@@ -20,6 +22,7 @@ public class ExternalSchemExModule extends AbstractModule {
     private static final String TYPE_PREFIX = TYPE_URI + "/";
     private static final String SCHEMEX_PROGRAM = "schemex";
     //sml:sourceFilePath
+    @Parameter(urlPrefix = SML.uri, name = "sourceFilePath")
     private Path sourceFilePath;
 
     @Override

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ImproveSPOWithMarginalsModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ImproveSPOWithMarginalsModule.java
@@ -5,6 +5,7 @@ import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.engine.ExecutionContextFactory;
 import cz.cvut.spipes.engine.VariablesBinding;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import cz.cvut.spipes.tdb.TDBTempFactory;
 import cz.cvut.spipes.util.JenaUtils;
 import cz.cvut.spipes.util.QueryUtils;
@@ -40,6 +41,7 @@ import org.slf4j.LoggerFactory;
 /**
  * TODO Order of queries is not enforced.
  */
+@SPipesModule(label = "improve spo with marginals", comment = "Improve spo with marginal resources.")
 public class ImproveSPOWithMarginalsModule extends AnnotatedAbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(ImproveSPOWithMarginalsModule.class);
@@ -48,13 +50,14 @@ public class ImproveSPOWithMarginalsModule extends AnnotatedAbstractModule {
     private static final String TYPE_URI = KBSS_MODULE.uri + MODULE_ID;
     private static final String TYPE_PREFIX = TYPE_URI + "/";
     private static Map<String, Model> marginalDefsModelCache = new HashMap<>();
-    //@Parameter(urlPrefix = TYPE_PREFIX, name = "marginal-constraint")
+
+    @Parameter(urlPrefix = TYPE_PREFIX, name = "marginal-constraint")
     private String marginalConstraint;
-    //@Parameter(urlPrefix = TYPE_PREFIX, name = "marginals-defs-file-url")
+    @Parameter(urlPrefix = TYPE_PREFIX, name = "marginals-defs-file-url")
     private String marginalsDefsFileUrl;
-    //@Parameter(urlPrefix = TYPE_PREFIX, name = "marginals-file-url")
+    @Parameter(urlPrefix = TYPE_PREFIX, name = "marginals-file-url")
     private String marginalsFileUrl;
-    //@Parameter(urlPrefix = TYPE_PREFIX, name = "data-service-url")
+    @Parameter(urlPrefix = TYPE_PREFIX, name = "data-service-url")
     private String dataServiceUrl;
 
     private static final String VAR_EXECUTION_ID = "executionId";

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/RetrieveGraphModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/RetrieveGraphModule.java
@@ -4,11 +4,13 @@ import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.engine.ExecutionContextFactory;
 import cz.cvut.spipes.impl.GraphChunkedDownload;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SPipesModule(label = "sparql endpoint retrieve graph", comment = "Load namedGraphId from sparql endpoint at endpointUrl.")
 public class RetrieveGraphModule extends AnnotatedAbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(RetrieveGraphModule.class);

--- a/s-pipes-modules/module-tabular/src/main/java/cz/cvut/spipes/modules/RDF2CSVModule.java
+++ b/s-pipes-modules/module-tabular/src/main/java/cz/cvut/spipes/modules/RDF2CSVModule.java
@@ -5,6 +5,7 @@ import cz.cvut.spipes.constants.KBSS_CSVW;
 import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.engine.ExecutionContextFactory;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
@@ -29,6 +30,9 @@ import java.util.stream.Collectors;
  * The table is constructed from column and row resources defined in TableSchema and saves it as a new CSV file.
  * </p>
  */
+@SPipesModule(label = "RDF2CSV", comment = "Module for converting RDF (representing table) to CSV. " +
+        "The module is responsible for converting the input RDF data into a CSV format and saving the output to a file." +
+        "The table is constructed from column and row resources defined in TableSchema and saves it as a new CSV file.")
 public class RDF2CSVModule extends AnnotatedAbstractModule {
 
     public static final String TYPE_URI = KBSS_MODULE.uri + "RDF2CSV";

--- a/s-pipes-modules/module-tabular/src/main/java/cz/cvut/spipes/modules/TabularModule.java
+++ b/s-pipes-modules/module-tabular/src/main/java/cz/cvut/spipes/modules/TabularModule.java
@@ -94,6 +94,7 @@ import java.util.function.Supplier;
 public class TabularModule extends AbstractModule {
 
     public static final String TYPE_URI = KBSS_MODULE.uri + "tabular";
+    public static final String PARAM_URL_PREFIX = TYPE_URI + "/";
     private static final Logger LOG = LoggerFactory.getLogger(TabularModule.class);
 
     private final Property P_DELIMITER = getSpecificParameter("delimiter");
@@ -106,30 +107,39 @@ public class TabularModule extends AbstractModule {
     private final Property P_PROCESS_HTML_FILE = getSpecificParameter("process-html-file");
 
     //sml:replace
+    @Parameter(urlPrefix = SML.uri, name = "replace")
     private boolean isReplace;
 
+    @Parameter(urlPrefix = PARAM_URL_PREFIX, name = "source-resource-uri")
     //:source-resource-uri
     private StreamResource sourceResource;
 
     //:delimiter
+    @Parameter(urlPrefix = PARAM_URL_PREFIX, name = "delimiter")
     private int delimiter;
 
     //:quote-character
+    @Parameter(urlPrefix = PARAM_URL_PREFIX, name = "quote-character")
     private char quoteCharacter;
 
     //:data-prefix
+    @Parameter(urlPrefix = PARAM_URL_PREFIX, name = "data-prefix")
     private String dataPrefix;
 
     //:skip-header
+    @Parameter(urlPrefix = PARAM_URL_PREFIX, name = "skip-header")
     private boolean skipHeader;
 
     //:process-html-file
+    @Parameter(urlPrefix = PARAM_URL_PREFIX, name = "process-html-file")
     private boolean processHTMLFile;
 
     //:output-mode
+    @Parameter(urlPrefix = PARAM_URL_PREFIX, name = "output-mode")
     private Mode outputMode;
 
     //:accept-invalid-quoting
+    @Parameter(urlPrefix = PARAM_URL_PREFIX, name = "accept-invalid-quoting")
     private boolean acceptInvalidQuoting;
 
     /**

--- a/s-pipes-modules/module-tarql/src/main/java/cz/cvut/spipes/modules/ModuleTarql.java
+++ b/s-pipes-modules/module-tarql/src/main/java/cz/cvut/spipes/modules/ModuleTarql.java
@@ -3,6 +3,7 @@ package cz.cvut.spipes.modules;
 import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.engine.ExecutionContextFactory;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
@@ -16,11 +17,12 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 @Deprecated //TODO merge with TarqlModule functionality
+@SPipesModule(label = "tarql-XXX-2", comment = "")
 public class ModuleTarql extends AbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(ModuleTarql.class);
 
-    private static final String TYPE_URI = KBSS_MODULE.getURI() + "tarql" + "-XXX-2";
+    private static final String TYPE_URI = KBSS_MODULE.uri + "tarql" + "-XXX-2";
 
     private static Property getParameter(final String name) {
         return ResourceFactory.createProperty(TYPE_URI + name);
@@ -30,18 +32,21 @@ public class ModuleTarql extends AbstractModule {
      * File with the TARQL script
      */
     static final Property P_TARQL_STRING = getParameter("p-tarql-string");
+    @Parameter(urlPrefix =TYPE_URI, name = "p-tarql-string")
     private String tarqlString;
 
     /**
      * Ontology IRI
      */
     static final Property P_ONTOLOGY_IRI = getParameter("p-ontology-iri");
+    @Parameter(urlPrefix = TYPE_URI, name = "p-ontology-iri")
     private String ontologyIRI;
 
     /**
      * Input File
      */
     static final Property P_INPUT_FILE = getParameter("p-input-file");
+    @Parameter(urlPrefix = TYPE_URI, name = "p-input-file")
     private String inputFile;
 
 //    /**

--- a/s-pipes-modules/module-tarql/src/main/java/cz/cvut/spipes/modules/TarqlModule.java
+++ b/s-pipes-modules/module-tarql/src/main/java/cz/cvut/spipes/modules/TarqlModule.java
@@ -5,6 +5,7 @@ import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.constants.SML;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.engine.ExecutionContextFactory;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import cz.cvut.spipes.registry.StreamResource;
 import cz.cvut.spipes.registry.StreamResourceRegistry;
 import org.apache.jena.ext.com.google.common.io.Files;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 // TODO merge with ModuleTarql functionality
+@SPipesModule(label = "tarql", comment = "Apply construct on a csv input.")
 public class TarqlModule extends AbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(TarqlModule.class);
@@ -35,14 +37,18 @@ public class TarqlModule extends AbstractModule {
     private static final String TARQL_PROGRAM = AppConstants.BIN_DIR + "/tarql";
 
     //sml:constructQuery
+    @Parameter(urlPrefix = SML.uri, name = "constructQuery")
     private List<Resource> constructQueries;
 
+    // TODO not used field
     private String tableFilePath;
 
     //sml:replace
+    @Parameter(urlPrefix = SML.uri, name = "replace")
     private boolean isReplace;
 
     //sml:sourceFilePath
+    @Parameter(urlPrefix = SML.uri, name = "sourceFilePath")
     private String sourceFilePath;
 
     public TarqlModule() {

--- a/s-pipes-modules/module-text-analysis/src/main/java/cz/cvut/spipes/modules/ExtractTermOccurrencesModule.java
+++ b/s-pipes-modules/module-text-analysis/src/main/java/cz/cvut/spipes/modules/ExtractTermOccurrencesModule.java
@@ -3,6 +3,7 @@ package cz.cvut.spipes.modules;
 import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.constants.SML;
 import cz.cvut.spipes.engine.ExecutionContext;
+import cz.cvut.spipes.modules.annotations.SPipesModule;
 import cz.cvut.spipes.modules.constants.Termit;
 import cz.cvut.spipes.modules.textAnalysis.Extraction;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -70,6 +71,10 @@ import java.util.Map;
  * .
  * </code></pre>
  */
+@SPipesModule(label = "extract term occurrences", comment =
+        "Module extracts term occurrences from annotated literals of input RDF." +
+        "Annotated literals are RDF string literals that are annotated by RDFa using TermIt terminology to mark " +
+        "occurrences of terms within the text.")
 public class ExtractTermOccurrencesModule extends AnnotatedAbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(ExtractTermOccurrencesModule.class);


### PR DESCRIPTION
Fixes #205, #206

#205
- delete incorrect sharing of parameter declaration among modules in writeConstraintsToModel
- add subClassOf triple to modules extending other modules, including abstract ones, to share parameter declaratoin with their super classes.
- Note that tools using the generated descriptions of modules that extend other modules will have to query the super classes for their parameter declaration.

#206
- Add SPipesModule and Parameter annotations to all modules in s-pipes-module subprojects.

