### PR TITLE
 Remove loadConfiguration where it is possible

### DIFF
--- a/s-pipes-core/src/main/java/cz/cvut/spipes/modules/AbstractModule.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/modules/AbstractModule.java
@@ -71,7 +71,6 @@ public abstract class AbstractModule implements Module {
     public ExecutionContext execute() {
         loadModuleFlags();
         loadConfiguration();
-        loadManualConfiguration();
         loadModuleConstraints();
         String inputModelFilePath = null;
         if (AuditConfig.isEnabled() || isInDebugMode) {

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/modules/AbstractModule.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/modules/AbstractModule.java
@@ -71,6 +71,7 @@ public abstract class AbstractModule implements Module {
     public ExecutionContext execute() {
         loadModuleFlags();
         loadConfiguration();
+        loadManualConfiguration();
         loadModuleConstraints();
         String inputModelFilePath = null;
         if (AuditConfig.isEnabled() || isInDebugMode) {

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/modules/AnnotatedAbstractModule.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/modules/AnnotatedAbstractModule.java
@@ -18,40 +18,67 @@ import java.util.Map;
  * {@link Parameter} annotation to indicate that they are configurable parameters.
  * The class will automatically detect these parameters, validate them, and populate
  * them with the appropriate values during the module's initialization.
- *
- * <p>The {@link #loadConfiguration()} method is overridden to handle this process.
- * It identifies all fields annotated with {@link Parameter}, checks for duplicate
- * parameter names, and uses the appropriate `Setter` and `Handler` implementations
- * to assign values to the fields.
  */
 public abstract class AnnotatedAbstractModule extends AbstractModule {
 
     private static final Logger log = LoggerFactory.getLogger(AnnotatedAbstractModule.class);
 
+    /**
+     * Loads the configuration for the module by scanning fields annotated with {@link Parameter}
+     * and setting their values using the appropriate {@link Setter} and {@link Handler} implementations.
+     *
+     * <p>This method is responsible for processing the fields declared in the class and its superclasses,
+     * that are annotated with {@link Parameter}. It ensures that each field is processed only once and
+     * verifies that no two fields share the same {@link Parameter#iri()}. If a duplicate is found,
+     * it throws a {@link RuntimeException}.
+     *
+     * <p>For each annotated field:
+     * <ul>
+     *   <li>A {@link Setter} is selected based on the field's type (e.g., {@link ListSetter} for lists).</li>
+     *   <li>The {@link HandlerRegistry} retrieves a matching {@link Handler} for the field's type,
+     *       which is responsible for setting the value of the field based on its {@link Parameter#iri()}.</li>
+     * </ul>
+     *
+     * <p>The method continues processing all declared fields, moving up through the class hierarchy
+     * until it reaches the {@code AnnotatedAbstractModule} class itself.
+     *
+     * <p>After all automatically configurable fields have been processed, it invokes the
+     * {@link #loadManualConfiguration()} method to allow subclasses to handle any custom configuration
+     * that requires manual intervention.
+     *
+     * @throws RuntimeException if two or more fields in the class hierarchy share the same
+     *         {@link Parameter#iri()}.
+     */
     @Override
     public void loadConfiguration() {
-        final Map<String, Field> vars = new HashMap<>();
-        for (final Field f : this.getClass().getDeclaredFields()) {
-            final Parameter p = f.getAnnotation(Parameter.class);
-            if (p == null) {
-                continue;
-            } else if (vars.containsKey(p.iri())) {
-                throw new RuntimeException(String.format("Two parameters have same iri %s", p.iri()));
-            } else {
-                vars.put(p.iri(), f);
-            }
 
-            log.trace("Processing parameter {} ", f.getName());
+        Class<? extends AnnotatedAbstractModule> clazz = this.getClass();
 
-            Setter setter;
-            if (f.getType() == List.class) {
-                setter = new ListSetter(f, this);
-            } else {
-                setter = new FieldSetter(f, this);
+        while(clazz != AnnotatedAbstractModule.class){
+            final Map<String, Field> vars = new HashMap<>();
+            for (final Field f : clazz.getDeclaredFields()) {
+                final Parameter p = f.getAnnotation(Parameter.class);
+                if (p == null) {
+                    continue;
+                } else if (vars.containsKey(p.iri())) {
+                    throw new RuntimeException(String.format("Two parameters have same iri %s", p.iri()));
+                } else {
+                    vars.put(p.iri(), f);
+                }
+
+                log.trace("Processing parameter {} ", f.getName());
+
+                Setter setter;
+                if (f.getType() == List.class) {
+                    setter = new ListSetter(f, this);
+                } else {
+                    setter = new FieldSetter(f, this);
+                }
+                HandlerRegistry handlerRegistry = HandlerRegistry.getInstance();
+                Handler<?> handler = handlerRegistry.getHandler(f.getType(), resource, executionContext, setter);
+                handler.setValueByProperty(ResourceFactory.createProperty(p.iri()));
             }
-            HandlerRegistry handlerRegistry = HandlerRegistry.getInstance();
-            Handler<?> handler = handlerRegistry.getHandler(f.getType(), resource, executionContext, setter);
-            handler.setValueByProperty(ResourceFactory.createProperty(p.iri()));
+            clazz = (Class<? extends AnnotatedAbstractModule>) clazz.getSuperclass();
         }
         loadManualConfiguration();
     }

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/modules/AnnotatedAbstractModule.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/modules/AnnotatedAbstractModule.java
@@ -54,4 +54,7 @@ public abstract class AnnotatedAbstractModule extends AbstractModule {
             handler.setValueByProperty(ResourceFactory.createProperty(p.iri()));
         }
     }
+
+    @Override
+    public void loadManualConfiguration(){}
 }

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/modules/AnnotatedAbstractModule.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/modules/AnnotatedAbstractModule.java
@@ -30,10 +30,10 @@ public abstract class AnnotatedAbstractModule extends AbstractModule {
 
     @Override
     public void loadConfiguration() {
-        final Map<String,Field> vars = new HashMap<>();
-        for(final Field f: this.getClass().getDeclaredFields()) {
+        final Map<String, Field> vars = new HashMap<>();
+        for (final Field f : this.getClass().getDeclaredFields()) {
             final Parameter p = f.getAnnotation(Parameter.class);
-            if ( p == null ) {
+            if (p == null) {
                 continue;
             } else if (vars.containsKey(p.iri())) {
                 throw new RuntimeException(String.format("Two parameters have same iri %s", p.iri()));
@@ -44,17 +44,33 @@ public abstract class AnnotatedAbstractModule extends AbstractModule {
             log.trace("Processing parameter {} ", f.getName());
 
             Setter setter;
-            if(f.getType() == List.class){
+            if (f.getType() == List.class) {
                 setter = new ListSetter(f, this);
-            }else{
+            } else {
                 setter = new FieldSetter(f, this);
             }
             HandlerRegistry handlerRegistry = HandlerRegistry.getInstance();
             Handler<?> handler = handlerRegistry.getHandler(f.getType(), resource, executionContext, setter);
             handler.setValueByProperty(ResourceFactory.createProperty(p.iri()));
         }
+        loadManualConfiguration();
     }
 
-    @Override
-    public void loadManualConfiguration(){}
+    /**
+     * This abstract method is intended to be overridden by subclasses to manually load
+     * specific configurations that are not automatically processed by the
+     * {@link #loadConfiguration()} method.
+     * <p>
+     * The {@link #loadConfiguration()} method first handles automated configuration by
+     * scanning annotated fields and invoking handlers to set their values. Once that
+     * process is complete, {@code loadManualConfiguration} is called to allow subclasses
+     * to define any additional custom configuration logic that is required.
+     * <p>
+     * Subclasses can choose to override this method to provide custom configurations
+     * that cannot be handled automatically. If no manual configuration is necessary,
+     * the default implementation can be used without changes.
+     */
+    public void loadManualConfiguration(){
+        // Default implementation: no manual configuration
+    };
 }

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/modules/Module.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/modules/Module.java
@@ -41,8 +41,6 @@ public interface Module {
      */
     void loadConfiguration();
 
-    void loadManualConfiguration();
-
     Resource getResource();
 
     void setInputModules(List<Module> inputModules);

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/modules/Module.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/modules/Module.java
@@ -41,6 +41,8 @@ public interface Module {
      */
     void loadConfiguration();
 
+    void loadManualConfiguration();
+
     Resource getResource();
 
     void setInputModules(List<Module> inputModules);

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/modules/handlers/HandlerRegistry.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/modules/handlers/HandlerRegistry.java
@@ -1,6 +1,7 @@
 package cz.cvut.spipes.modules.handlers;
 
 import cz.cvut.spipes.engine.ExecutionContext;
+import cz.cvut.spipes.registry.StreamResource;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.topbraid.spin.model.Select;
@@ -59,6 +60,7 @@ public class HandlerRegistry {
         registerHandler(Path.class, PathHandler.class);
         registerHandler(Resource.class, ResourceHandler.class);
         registerHandler(List.class, ListHandler.class);
+        registerHandler(StreamResource.class, StreamResourceHandler.class);
     }
 
     public synchronized Handler getHandler(Class clazz, Resource resource, ExecutionContext context, Setter setter) {

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/modules/handlers/StreamResourceHandler.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/modules/handlers/StreamResourceHandler.java
@@ -1,0 +1,26 @@
+package cz.cvut.spipes.modules.handlers;
+
+import cz.cvut.spipes.engine.ExecutionContext;
+import cz.cvut.spipes.exception.ResourceNotFoundException;
+import cz.cvut.spipes.registry.StreamResource;
+import cz.cvut.spipes.registry.StreamResourceRegistry;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+
+public class StreamResourceHandler extends BaseRDFNodeHandler<StreamResource> {
+
+    public StreamResourceHandler(Resource resource, ExecutionContext executionContext, Setter<? super StreamResource> setter) {
+        super(resource, executionContext, setter);
+    }
+
+    @Override
+    StreamResource getRDFNodeValue(RDFNode node) throws Exception {
+        StreamResource res = StreamResourceRegistry.getInstance().getResourceByUrl(node.asLiteral().toString());
+
+        if (res == null) {
+            throw new ResourceNotFoundException("Stream resource " + node.asLiteral().toString() + " not found. ");
+        }
+
+        return res;
+    }
+}

--- a/s-pipes-modules/module-dataset-discovery/src/main/java/cz/cvut/spipes/modules/DatasetDiscoveryModule.java
+++ b/s-pipes-modules/module-dataset-discovery/src/main/java/cz/cvut/spipes/modules/DatasetDiscoveryModule.java
@@ -35,13 +35,8 @@ public class DatasetDiscoveryModule extends AnnotatedAbstractModule {
 
     private static final String TYPE_URI = KBSS_MODULE.uri + "dataset-discovery-v1";
 
-    private static final Property P_USER_INPUT = getParameter("prp-user-input");
     @Parameter(iri = TYPE_URI + "/" + "prp-user-input", comment = "Keywords query. Keywords are separated by space.")
     private String userInput;
-
-    private static Property getParameter(final String name) {
-        return ResourceFactory.createProperty(TYPE_URI + "/" + name);
-    }
 
     private List<String> getDatasetsForQuery(final String s, final String endpoint) {
         final List<String> datasets = new ArrayList<>();

--- a/s-pipes-modules/module-dataset-discovery/src/main/java/cz/cvut/spipes/modules/DatasetDiscoveryModule.java
+++ b/s-pipes-modules/module-dataset-discovery/src/main/java/cz/cvut/spipes/modules/DatasetDiscoveryModule.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 @SPipesModule(label = "dataset discovery v1", comment =
         "Discovers dataset based on keyword userInput in repository linked.opendata.cz-federated-descriptor-faceted-search " +
         "hosted at http://onto.fel.cvut.cz/rdf4j-server.")
-public class DatasetDiscoveryModule extends AbstractModule {
+public class DatasetDiscoveryModule extends AnnotatedAbstractModule {
 
     private static final String TYPE_URI = KBSS_MODULE.uri + "dataset-discovery-v1";
 
@@ -138,8 +138,4 @@ public class DatasetDiscoveryModule extends AbstractModule {
         return TYPE_URI;
     }
 
-    @Override
-    public void loadConfiguration() {
-        userInput = this.getStringPropertyValue(P_USER_INPUT);
-    }
 }

--- a/s-pipes-modules/module-dataset-discovery/src/main/java/cz/cvut/spipes/modules/GetDatasetDescriptorsModule.java
+++ b/s-pipes-modules/module-dataset-discovery/src/main/java/cz/cvut/spipes/modules/GetDatasetDescriptorsModule.java
@@ -3,6 +3,8 @@ package cz.cvut.spipes.modules;
 import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.modules.annotations.SPipesModule;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
@@ -20,18 +22,13 @@ import java.util.Collections;
 import java.util.Optional;
 
 @Slf4j
+@Getter
+@Setter
 @SPipesModule(label = "get dataset descriptors v1", comment = "Retrieve dataset descriptor for dataset" +
     " with dataset-iri in endpoint-url.")
-public class GetDatasetDescriptorsModule extends AbstractModule {
+public class GetDatasetDescriptorsModule extends AnnotatedAbstractModule {
 
     private static final String TYPE_URI = KBSS_MODULE.uri + "get-dataset-descriptors-v1";
-    private static final String PARAM_URI = TYPE_URI + "/";
-
-    /**
-     * URL of the Sesame server.
-     */
-    private static final Property P_DATASET_IRI = getParameter("p-dataset-iri");
-    private static final Property P_ENDPOINT_URL = getParameter("endpoint-url");
 
     @Parameter(iri = TYPE_URI + "/" + "p-dataset-iri", comment = "IRI of the dataset.")// TODO - revise comment
     private String prpDatasetIri;
@@ -39,18 +36,6 @@ public class GetDatasetDescriptorsModule extends AbstractModule {
     @Parameter(iri = TYPE_URI + "/" + "endpoint-url", comment = "URL of the SPARQL endpoint. Default value" +
         " is 'http://onto.fel.cvut.cz/rdf4j-server/repositories/descriptors-metadata'")
     private String endpointUrl = "http://onto.fel.cvut.cz/rdf4j-server/repositories/descriptors-metadata";
-
-    private static Property getParameter(final String name) {
-        return ResourceFactory.createProperty(TYPE_URI + "/" + name);
-    }
-
-    public String getPrpDatasetIri() {
-        return prpDatasetIri;
-    }
-
-    public void setPrpDatasetIri(String prpDatasetIri) {
-        this.prpDatasetIri = prpDatasetIri;
-    }
 
     @Override
     ExecutionContext executeSelf() {
@@ -96,9 +81,4 @@ public class GetDatasetDescriptorsModule extends AbstractModule {
         return TYPE_URI;
     }
 
-    @Override
-    public void loadConfiguration() {
-        prpDatasetIri = this.getStringPropertyValue(P_DATASET_IRI);
-        endpointUrl = Optional.ofNullable(this.getStringPropertyValue(P_ENDPOINT_URL)).orElse(endpointUrl);
-    }
 }

--- a/s-pipes-modules/module-eccairs/src/main/java/cz/cvut/spipes/modules/ImportE5XModule.java
+++ b/s-pipes-modules/module-eccairs/src/main/java/cz/cvut/spipes/modules/ImportE5XModule.java
@@ -43,9 +43,8 @@ public class ImportE5XModule extends AnnotatedAbstractModule {
 
     // TODO - this parameter id defined with IRI <http://onto.fel.cvut.cz/ontologies/lib/module-param/has-resource-uri> in  s-pipes-modules\module.sms.ttl
     // TODO - we should be able to annotate directly "StreamResource e5xResource" instead
-    @Parameter(iri = KBSS_MODULE.has_resource_uri, comment = "Uri of a resource referencing content of an e5x file.")
-    private String e5xResourceUriStr;
 
+    @Parameter(iri = KBSS_MODULE.has_resource_uri, comment = "Uri of a resource referencing content of an e5x file.")
     StreamResource e5xResource;
 
     private boolean computeEccairsToAviationSafetyOntologyMapping = true;
@@ -149,23 +148,6 @@ public class ImportE5XModule extends AnnotatedAbstractModule {
     @Override
     public String getTypeURI() {
         return KBSS_MODULE.uri + "import-e5x";
-    }
-
-    @Override
-    public void loadConfiguration() {
-        e5xResourceUriStr = getEffectiveValue(KBSS_MODULE.JENA.has_resource_uri).asLiteral().toString();
-        e5xResource = getResourceByUri(e5xResourceUriStr);
-    }
-
-    @NotNull
-    private StreamResource getResourceByUri(@NotNull String e5xResourceUriStr) {
-
-        StreamResource res = StreamResourceRegistry.getInstance().getResourceByUrl(e5xResourceUriStr);
-
-        if (res == null) {
-            throw new ResourceNotFoundException("Stream resource " + e5xResourceUriStr + " not found. ");
-        }
-        return res;
     }
 
 }

--- a/s-pipes-modules/module-eccairs/src/main/java/cz/cvut/spipes/modules/ImportE5XModule.java
+++ b/s-pipes-modules/module-eccairs/src/main/java/cz/cvut/spipes/modules/ImportE5XModule.java
@@ -22,6 +22,8 @@ import cz.cvut.spipes.modules.eccairs.SesameDataDao;
 import cz.cvut.spipes.registry.StreamResource;
 import cz.cvut.spipes.registry.StreamResourceRegistry;
 import cz.cvut.spipes.util.JenaUtils;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.util.FileUtils;
@@ -34,8 +36,10 @@ import java.net.URI;
 import java.util.Arrays;
 
 @Slf4j
+@Getter
+@Setter
 @SPipesModule(label = "import e5x", comment = "Convert e5x xml files to rdf.")
-public class ImportE5XModule extends AbstractModule {
+public class ImportE5XModule extends AnnotatedAbstractModule {
 
     // TODO - this parameter id defined with IRI <http://onto.fel.cvut.cz/ontologies/lib/module-param/has-resource-uri> in  s-pipes-modules\module.sms.ttl
     // TODO - we should be able to annotate directly "StreamResource e5xResource" instead
@@ -153,22 +157,6 @@ public class ImportE5XModule extends AbstractModule {
         e5xResource = getResourceByUri(e5xResourceUriStr);
     }
 
-    public String getE5xResourceUri() {
-        return e5xResource.getUri();
-    }
-
-    public StreamResource getE5xResource() {
-        return e5xResource;
-    }
-
-    public void setE5xResourceUri(String e5xResourceUri) {
-        e5xResource = getResourceByUri(e5xResourceUri);
-    }
-
-    public void setE5xResource(@NotNull StreamResource e5xResource) {
-        this.e5xResource = e5xResource;
-    }
-
     @NotNull
     private StreamResource getResourceByUri(@NotNull String e5xResourceUriStr) {
 
@@ -180,11 +168,4 @@ public class ImportE5XModule extends AbstractModule {
         return res;
     }
 
-    public boolean isComputeEccairsToAviationSafetyOntologyMapping() {
-        return computeEccairsToAviationSafetyOntologyMapping;
-    }
-
-    public void setComputeEccairsToAviationSafetyOntologyMapping(boolean computeEccairsToAviationSafetyOntologyMapping) {
-        this.computeEccairsToAviationSafetyOntologyMapping = computeEccairsToAviationSafetyOntologyMapping;
-    }
 }

--- a/s-pipes-modules/module-identity/src/main/java/cz/cvut/spipes/modules/IdentityModule.java
+++ b/s-pipes-modules/module-identity/src/main/java/cz/cvut/spipes/modules/IdentityModule.java
@@ -11,7 +11,6 @@ public class IdentityModule extends AnnotatedAbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(IdentityModule.class);
 
-
     @Override
     ExecutionContext executeSelf() {
         return executionContext;
@@ -22,7 +21,4 @@ public class IdentityModule extends AnnotatedAbstractModule {
         return KBSS_MODULE.uri + "identity";
     }
 
-    @Override
-    public void loadConfiguration() {
-    }
 }

--- a/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModule.java
+++ b/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModule.java
@@ -30,7 +30,7 @@ import java.nio.file.Paths;
 
 @Slf4j
 @SPipesModule(label = "temporal v0.1", comment = "Annotate temporal expressions in literals in input model.")
-public class SUTimeModule extends AbstractModule {
+public class SUTimeModule extends AnnotatedAbstractModule {
 
     public static final String TYPE_URI = KBSS_MODULE.uri + "temporal-v0.1";
 
@@ -40,7 +40,6 @@ public class SUTimeModule extends AbstractModule {
     @Parameter(iri = DescriptorModel.has_document_date, comment = "Document date format.") // TODO - revise comment
     private String documentDate; // TODO support other formats ?
 
-
     public SUTimeModule() {
     }
 
@@ -49,17 +48,6 @@ public class SUTimeModule extends AbstractModule {
         return TYPE_URI;
     }
 
-    @Override
-    public void loadConfiguration() {
-
-        if (this.resource.getProperty(DescriptorModel.JENA.has_document_date) != null) { // TODO set current date if not specified
-            documentDate = getEffectiveValue(DescriptorModel.JENA.has_document_date).asLiteral().toString();
-        }
-
-        if (this.resource.getProperty(DescriptorModel.JENA.has_rule_file) != null) { //TODO support more rule files
-            ruleFilePaths.add(Paths.get(getEffectiveValue(DescriptorModel.JENA.has_rule_file).asLiteral().toString()));
-        }
-    }
 
     @Override
 
@@ -70,11 +58,7 @@ public class SUTimeModule extends AbstractModule {
     }
 
     private Model analyzeModel(Model m) {
-
-
-
         AnnotationPipeline pipeline = loadPipeline();
-
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         List<ReifiedStatement> temporalAnnotationStmts = new LinkedList<>();
@@ -198,8 +182,5 @@ public class SUTimeModule extends AbstractModule {
         pipeline.addAnnotator(new TimeAnnotator("sutime", props));
         return pipeline;
     }
-
-
-
 
 }

--- a/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModuleNew.java
+++ b/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModuleNew.java
@@ -48,7 +48,7 @@ public class SUTimeModuleNew extends AnnotatedAbstractModule {
     private static final Property P_PAGE_SIZE = ResourceFactory.createProperty(TYPE_PREFIX + "page-size");
 
     @Parameter(iri = TYPE_PREFIX + "page-size", comment = "Page size. Default value is 10000.")
-    private Integer pageSize = DEFAULT_PAGE_SIZE;
+    private int pageSize = DEFAULT_PAGE_SIZE;
 
     @Parameter(iri = SML.constructQuery,
             comment = "List of construct queries. The module annotates the lexical form of objects of the output statements of these queries.")// TODO - revise comment

--- a/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jCreateRepositoryModule.java
+++ b/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jCreateRepositoryModule.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 
 @Slf4j
 @SPipesModule(label = "rdf4j create repository", comment = "Module creates native store rdf4j repository on the given server with the given name.")
-public class Rdf4jCreateRepositoryModule extends AbstractModule {
+public class Rdf4jCreateRepositoryModule extends AnnotatedAbstractModule {
     private static final String TYPE_URI = KBSS_MODULE.uri + "rdf4j-create-repository";
     private static final String PROPERTY_PREFIX_URI = KBSS_MODULE.uri + "rdf4j";
 
@@ -34,8 +34,9 @@ public class Rdf4jCreateRepositoryModule extends AbstractModule {
 
     @Parameter(iri = PROPERTY_PREFIX_URI + "/" + "p-rdf4j-ignore-if-exists",
             comment = "Don't try to create new repository if it already exists (Default value is false)")
-    private boolean rdf4jIgnoreIfExists;
+    private boolean rdf4jIgnoreIfExists = false;
 
+    @Parameter(iri = PROPERTY_PREFIX_URI + "/" + "p-rdf4j-server-url", comment = "URL of the Rdf4j server")
     private RepositoryManager repositoryManager;
 
     public String getRdf4jServerURL() {
@@ -101,15 +102,7 @@ public class Rdf4jCreateRepositoryModule extends AbstractModule {
     }
 
     @Override
-    public void loadConfiguration() {
-        rdf4jServerURL = getEffectiveValue(P_RDF4J_SERVER_URL).asLiteral().getString();
-        rdf4jRepositoryName = getEffectiveValue(P_RDF4J_REPOSITORY_NAME).asLiteral().getString();
-        try {
-            rdf4jIgnoreIfExists = (Objects.equals(getEffectiveValue(P_RDF4J_IGNORE_IF_EXISTS).asLiteral().getString(), "true"));
-        }
-        catch (NullPointerException e){
-            rdf4jIgnoreIfExists = false;
-        }
+    public void loadManualConfiguration() {
         repositoryManager = new RemoteRepositoryManager(rdf4jServerURL);
     }
 }

--- a/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jDeployModule.java
+++ b/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jDeployModule.java
@@ -10,8 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFLanguages;
 import org.eclipse.rdf4j.model.Resource;
@@ -28,12 +26,12 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreConfig;
 import org.jetbrains.annotations.NotNull;
+
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Optional;
 
 @Slf4j
 @SPipesModule(label = "deploy", comment =
@@ -45,23 +43,14 @@ public class Rdf4jDeployModule extends AnnotatedAbstractModule {
     private final static String TYPE_URI = KBSS_MODULE.uri + "deploy";
     private final static String PROPERTY_PREFIX_URI = KBSS_MODULE.uri + "rdf4j";
 
-    private static Property getParameter(final String name) {
-        return ResourceFactory.createProperty(PROPERTY_PREFIX_URI + "/" + name);
-    }
-
-    static final Property P_RDF4J_SERVER_URL = getParameter("p-rdf4j-server-url");
     @Parameter(iri = PROPERTY_PREFIX_URI + "/" + "p-rdf4j-server-url", comment = "URL of the Rdf4j server")
     private String rdf4jServerURL;
 
-    static final Property P_RDF4J_REPOSITORY_NAME = getParameter("p-rdf4j-repository-name");
     @Parameter(iri = PROPERTY_PREFIX_URI + "/" + "p-rdf4j-repository-name", comment = "Rdf4j repository ID")
     private String rdf4jRepositoryName;
 
-    static final Property P_RDF4J_CONTEXT_IRI = getParameter("p-rdf4j-context-iri");
     @Parameter(iri = PROPERTY_PREFIX_URI + "/" + "p-rdf4j-context-iri", comment = "IRI of the context that should be used for deployment.")
     private String rdf4jContextIRI;
-
-    static final Property P_RDF4J_INFER_CONTEXT_IRIS = getParameter("p-rdf4j-infer-context-iris");
 
     @Parameter(iri = PROPERTY_PREFIX_URI + "/" + "p-rdf4j-infer-context-iris",
         comment = "IRI of contexts is inferred from annotated input triples. Only reified triples that contain triple " +
@@ -69,7 +58,6 @@ public class Rdf4jDeployModule extends AnnotatedAbstractModule {
             " Actual triples related to reified statement are not processed/needed. Default is false.")
     private boolean inferContextIRIs = false;
 
-    static final Property P_RDF4J_REPOSITORY_USERNAME = getParameter("p-rdf4j-secured-username-variable");
     @Parameter(iri = PROPERTY_PREFIX_URI + "/" + "p-rdf4j-secured-username-variable", comment = "User name if the repository requires authentication.")
     private String rdf4jSecuredUsernameVariable;
 
@@ -81,11 +69,9 @@ public class Rdf4jDeployModule extends AnnotatedAbstractModule {
         this.repositoryManager = repositoryManager;
     }
 
-    static final Property P_RDF4J_REPOSITORY_PASSWORD = getParameter("p-rdf4j-secured-password-variable");
     @Parameter(iri = PROPERTY_PREFIX_URI + "/" + "p-rdf4j-secured-password-variable", comment = "Password if the repository requires authentication.")
     private String rdf4jSecuredPasswordVariable;
 
-    static final Property P_IS_REPLACE_CONTEXT_IRI = getParameter("p-is-replace");
     @Parameter(iri = PROPERTY_PREFIX_URI + "/" + "p-is-replace", comment =
             "Whether data should be replaced (true) / appended (false) into the specified context or repository.\n" +
             "Default is false.")

--- a/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jUpdateModule.java
+++ b/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jUpdateModule.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 @SPipesModule(label = "rdf4j update", comment = "Updates sparql endpoint configured in rdf4jServerURL" +
     " using specified list updateQueries. The list of queries can be executed multiple times specified by " +
     " `has-max-iteration-count` property.")
-public class Rdf4jUpdateModule extends AbstractModule {
+public class Rdf4jUpdateModule extends AnnotatedAbstractModule {
     private static final String TYPE_URI = KBSS_MODULE.uri + "rdf4j-update";
     private static final String PROPERTY_PREFIX_URI = KBSS_MODULE.uri + "rdf4j";
 
@@ -56,13 +56,13 @@ public class Rdf4jUpdateModule extends AbstractModule {
     @Parameter(iri = PROPERTY_PREFIX_URI + "/" + "p-stop-iteration-on-stable-triple-count",
             comment = "Stops iteration (i.e. execution of list of queries) if triple count " +
                 "in the last iteration did not change. Default is false.")
-    private boolean onlyIfTripleCountChanges;
+    private boolean onlyIfTripleCountChanges = false;
 
     @Parameter(iri = PROPERTY_PREFIX_URI + "/" + "has-max-iteration-count",
             comment = "Limits the number of iterations (i.e. executions of list of queries)" +
                 " to the specified value. Default value is 1, which means that all" +
                 " update queries are executed only once.")
-    private int iterationCount;
+    private int iterationCount = 1;
 
     private Repository updateRepository;
 
@@ -189,11 +189,7 @@ public class Rdf4jUpdateModule extends AbstractModule {
     }
 
     @Override
-    public void loadConfiguration() {
-        rdf4jServerURL = getEffectiveValue(P_RDF4J_SERVER_URL).asLiteral().getString();
-        rdf4jRepositoryName = getEffectiveValue(P_RDF4J_REPOSITORY_NAME).asLiteral().getString();
-        iterationCount = getPropertyValue(KBSS_MODULE.JENA.has_max_iteration_count,1);
-        onlyIfTripleCountChanges = getPropertyValue(P_RDF4J_STOP_ITERATION_ON_STABLE_TRIPLE_COUNT,false);
+    public void loadManualConfiguration() {
         log.debug("Iteration count={}\nOnlyIf...Changes={}"
                 ,iterationCount
                 ,onlyIfTripleCountChanges);

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructAbstractModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructAbstractModule.java
@@ -137,23 +137,9 @@ public abstract class ApplyConstructAbstractModule extends AnnotatedAbstractModu
         return queryStr;
     }
 
-//    @Override
-//    public void loadConfiguration() {
-//
-//        // TODO sparql expressions
-//        // TODO load default values from configuration
-//
-//        // TODO does not work with string query as object is not RDF resource ???
-//        constructQueries = getResourcesByProperty(SML.JENA.constructQuery);
-//
-//        log.debug("Loaded {} spin construct queries.", constructQueries.size());
-//
-//        //TODO default value must be taken from template definition
-//        isReplace = this.getPropertyValue(SML.JENA.replace, false);
-//
-//        parseText = this.getPropertyValue(KBSS_MODULE.JENA.is_parse_text, true);
-//        iterationCount = this.getPropertyValue(KBSS_MODULE.JENA.has_max_iteration_count, -1);
-//    }
-
+    @Override
+    public void loadManualConfiguration(){
+        log.debug("Loaded {} spin construct queries.", constructQueries.size());
+    }
 
 }

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructAbstractModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructAbstractModule.java
@@ -5,6 +5,8 @@ import cz.cvut.spipes.constants.SML;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.util.JenaUtils;
 import cz.cvut.spipes.util.QueryUtils;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryFactory;
@@ -19,6 +21,8 @@ import org.topbraid.spin.vocabulary.SP;
 import java.util.List;
 
 @Slf4j
+@Getter
+@Setter
 public abstract class ApplyConstructAbstractModule extends AnnotatedAbstractModule {
 
     private static final String TYPE_URI = KBSS_MODULE.uri + "abstract-apply-construct";
@@ -33,13 +37,13 @@ public abstract class ApplyConstructAbstractModule extends AnnotatedAbstractModu
     @Parameter(iri = SML.replace, comment = "Specifies whether a module should overwrite triples" +
         " from its predecessors. When set to true (default is false), it prevents" +
         " passing through triples from the predecessors.")
-    protected boolean isReplace;
+    protected boolean isReplace = false;
 
     @Parameter(iri = KBSS_MODULE.is_parse_text,
             comment = "Whether the query should be taken from sp:text property instead of from SPIN serialization," +
                 " default is true."
     )
-    protected boolean parseText;
+    protected boolean parseText = true;
 
     @Parameter(iri = KBSS_MODULE.has_max_iteration_count,
             comment =
@@ -57,44 +61,10 @@ public abstract class ApplyConstructAbstractModule extends AnnotatedAbstractModu
     )
     protected int iterationCount = -1;
 
-
     public ApplyConstructAbstractModule() {
         // TODO move elsewhere
         SPINModuleRegistry.get().init(); //TODO -- downloads spin from the web (should be cached instead)
     }
-
-    public boolean isParseText() {
-        return parseText;
-    }
-
-    public void setParseText(boolean parseText) {
-        this.parseText = parseText;
-    }
-
-    public boolean isReplace() {
-        return isReplace;
-    }
-
-    public void setReplace(boolean replace) {
-        isReplace = replace;
-    }
-
-    public List<Resource> getConstructQueries() {
-        return constructQueries;
-    }
-
-    public void setConstructQueries(List<Resource> constructQueries) {
-        this.constructQueries = constructQueries;
-    }
-
-    public int getIterationCount() {
-        return iterationCount;
-    }
-
-    public void setIterationCount(int iterationCount) {
-        this.iterationCount = iterationCount;
-    }
-
 
     protected QuerySolution generateIterationBinding(int currentIteration, QuerySolution globalBinding) {
         return globalBinding;
@@ -167,23 +137,23 @@ public abstract class ApplyConstructAbstractModule extends AnnotatedAbstractModu
         return queryStr;
     }
 
-    @Override
-    public void loadConfiguration() {
-
-        // TODO sparql expressions
-        // TODO load default values from configuration
-
-        // TODO does not work with string query as object is not RDF resource ???
-        constructQueries = getResourcesByProperty(SML.JENA.constructQuery);
-
-        log.debug("Loaded {} spin construct queries.", constructQueries.size());
-
-        //TODO default value must be taken from template definition
-        isReplace = this.getPropertyValue(SML.JENA.replace, false);
-
-        parseText = this.getPropertyValue(KBSS_MODULE.JENA.is_parse_text, true);
-        iterationCount = this.getPropertyValue(KBSS_MODULE.JENA.has_max_iteration_count, -1);
-    }
+//    @Override
+//    public void loadConfiguration() {
+//
+//        // TODO sparql expressions
+//        // TODO load default values from configuration
+//
+//        // TODO does not work with string query as object is not RDF resource ???
+//        constructQueries = getResourcesByProperty(SML.JENA.constructQuery);
+//
+//        log.debug("Loaded {} spin construct queries.", constructQueries.size());
+//
+//        //TODO default value must be taken from template definition
+//        isReplace = this.getPropertyValue(SML.JENA.replace, false);
+//
+//        parseText = this.getPropertyValue(KBSS_MODULE.JENA.is_parse_text, true);
+//        iterationCount = this.getPropertyValue(KBSS_MODULE.JENA.has_max_iteration_count, -1);
+//    }
 
 
 }

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructV2Module.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructV2Module.java
@@ -21,7 +21,7 @@ public class ApplyConstructV2Module extends ApplyConstructAbstractModule {
 
     @Override
     public void loadManualConfiguration() {
-        super.loadConfiguration();
+        super.loadManualConfiguration();
         iterationCount = this.getPropertyValue(KBSS_MODULE.JENA.has_max_iteration_count, 1);
     }
 }

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructV2Module.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructV2Module.java
@@ -20,7 +20,7 @@ public class ApplyConstructV2Module extends ApplyConstructAbstractModule {
 
 
     @Override
-    public void loadConfiguration() {
+    public void loadManualConfiguration() {
         super.loadConfiguration();
         iterationCount = this.getPropertyValue(KBSS_MODULE.JENA.has_max_iteration_count, 1);
     }

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithChunkedValuesAndScrollableCursorModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithChunkedValuesAndScrollableCursorModule.java
@@ -107,7 +107,6 @@ public class ApplyConstructWithChunkedValuesAndScrollableCursorModule extends Ap
 
     @Override
     public void loadManualConfiguration() {
-        super.loadConfiguration();
         super.loadManualConfiguration();
         //iterationCount = this.getPropertyValue(KBSS_MODULE.JENA.s_max_iteration_count, 1);
     }

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithChunkedValuesAndScrollableCursorModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithChunkedValuesAndScrollableCursorModule.java
@@ -106,13 +106,10 @@ public class ApplyConstructWithChunkedValuesAndScrollableCursorModule extends Ap
 
 
     @Override
-    public void loadConfiguration() {
+    public void loadManualConfiguration() {
         super.loadConfiguration();
+        super.loadManualConfiguration();
         //iterationCount = this.getPropertyValue(KBSS_MODULE.JENA.s_max_iteration_count, 1);
-        parseText = this.getPropertyValue(KBSS_MODULE.JENA.is_parse_text, true);
-        chunkSize = this.getPropertyValue(P_CHUNK_SIZE, DEFAULT_CHUNK_SIZE);
-        selectQuery = getPropertyValue(SML.JENA.selectQuery).asResource().as(Select.class);
-        pageSize = this.getPropertyValue(P_PAGE_SIZE, DEFAULT_PAGE_SIZE);
     }
 
     @NotNull

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithChunkedValuesModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithChunkedValuesModule.java
@@ -114,7 +114,7 @@ public class ApplyConstructWithChunkedValuesModule extends ApplyConstructAbstrac
 
     @Override
     public void loadManualConfiguration() {
-        super.loadConfiguration();
+        super.loadManualConfiguration();
         //iterationCount = this.getPropertyValue(KBSS_MODULE.JENA.s_max_iteration_count, 1);
     }
 

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithChunkedValuesModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithChunkedValuesModule.java
@@ -113,12 +113,9 @@ public class ApplyConstructWithChunkedValuesModule extends ApplyConstructAbstrac
 
 
     @Override
-    public void loadConfiguration() {
+    public void loadManualConfiguration() {
         super.loadConfiguration();
         //iterationCount = this.getPropertyValue(KBSS_MODULE.JENA.s_max_iteration_count, 1);
-        parseText = this.getPropertyValue(KBSS_MODULE.JENA.is_parse_text, true);
-        chunkSize = this.getPropertyValue(P_CHUNK_SIZE, DEFAULT_CHUNK_SIZE);
-        selectQuery = getPropertyValue(SML.JENA.selectQuery).asResource().as(Select.class);
     }
 
     @NotNull

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithScrollableCursorModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithScrollableCursorModule.java
@@ -77,7 +77,7 @@ public class ApplyConstructWithScrollableCursorModule extends ApplyConstructAbst
 
     @Override
     public void loadManualConfiguration() {
-        super.loadConfiguration();
+        super.loadManualConfiguration();
         //iterationCount = this.getPropertyValue(KBSS_MODULE.JENA.s_max_iteration_count, 1);
     }
 }

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithScrollableCursorModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ApplyConstructWithScrollableCursorModule.java
@@ -76,10 +76,8 @@ public class ApplyConstructWithScrollableCursorModule extends ApplyConstructAbst
 
 
     @Override
-    public void loadConfiguration() {
+    public void loadManualConfiguration() {
         super.loadConfiguration();
         //iterationCount = this.getPropertyValue(KBSS_MODULE.JENA.s_max_iteration_count, 1);
-        parseText = this.getPropertyValue(KBSS_MODULE.JENA.is_parse_text, true);
-        pageSize = this.getPropertyValue(P_PAGE_SIZE , DEFAULT_PAGE_SIZE);
     }
 }

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/DownloadGraphModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/DownloadGraphModule.java
@@ -40,7 +40,7 @@ public class DownloadGraphModule extends AnnotatedAbstractModule {
     private String outputResourceVariable;
 
     @Parameter(iri = TYPE_PREFIX + "page-size", comment = "Page size. Default value is 10000.")
-    private Integer pageSize = DEFAULT_PAGE_SIZE;
+    private int pageSize = DEFAULT_PAGE_SIZE;
 
     protected long numberOfDownloadedTriples;
 

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/DownloadGraphModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/DownloadGraphModule.java
@@ -12,12 +12,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import cz.cvut.spipes.modules.annotations.SPipesModule;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
+
 @Slf4j
+@Getter
+@Setter
 @SPipesModule(label = "sparql endpoint download graph", comment = "Downloads named graph namedGraphId from sparql endpoint endpointUrl.")
 public class DownloadGraphModule extends AnnotatedAbstractModule {
 
@@ -39,48 +44,8 @@ public class DownloadGraphModule extends AnnotatedAbstractModule {
 
     protected long numberOfDownloadedTriples;
 
-    public String getNamedGraphId() {
-        return namedGraphId;
-    }
-
-    public void setNamedGraphId(String namedGraphId) {
-        this.namedGraphId = namedGraphId;
-    }
-
     public String getTypeURI() {
         return TYPE_URI;
-    }
-
-    public String getEndpointUrl() {
-        return endpointUrl;
-    }
-
-    public void setEndpointUrl(String endpointUrl) {
-        this.endpointUrl = endpointUrl;
-    }
-
-    public int getPageSize() {
-        return pageSize;
-    }
-
-    public void setPageSize(int pageSize) {
-        this.pageSize = pageSize;
-    }
-
-    public String getOutputResourceVariable() {
-        return outputResourceVariable;
-    }
-
-    public void setOutputResourceVariable(String outputResourceVariable) {
-        this.outputResourceVariable = outputResourceVariable;
-    }
-
-    public long getNumberOfDownloadedTriples() {
-        return numberOfDownloadedTriples;
-    }
-
-    public void setNumberOfDownloadedTriples(long numberOfDownloadedTriples) {
-        this.numberOfDownloadedTriples = numberOfDownloadedTriples;
     }
 
     @Override

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ExternalSchemExModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ExternalSchemExModule.java
@@ -16,13 +16,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 @SPipesModule(label = "external schemex", comment = "Compute schemex using external script for a specified sourceFilePath.")
-public class ExternalSchemExModule extends AbstractModule {
+public class ExternalSchemExModule extends AnnotatedAbstractModule {
 
     private static final String MODULE_ID = "external-schemex";
     private static final String TYPE_URI = KBSS_MODULE.uri + MODULE_ID;
     private static final String TYPE_PREFIX = TYPE_URI + "/";
     private static final String SCHEMEX_PROGRAM = "schemex";
-    //sml:sourceFilePath
+
     @Parameter(iri = SML.sourceFilePath, comment = "Source file in nt format.")
     private Path sourceFilePath;
 
@@ -63,10 +63,4 @@ public class ExternalSchemExModule extends AbstractModule {
         return TYPE_URI;
     }
 
-    @Override
-    public void loadConfiguration() {
-
-        sourceFilePath = Paths.get(getEffectiveValue(SML.JENA.sourceFilePath).asLiteral().toString());
-
-    }
 }

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ImproveSPOWithMarginalsModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ImproveSPOWithMarginalsModule.java
@@ -380,12 +380,8 @@ public class ImproveSPOWithMarginalsModule extends AnnotatedAbstractModule {
     }
 
     @Override
-    public void loadConfiguration() {
+    public void loadManualConfiguration() {
         super.loadConfiguration();
-        marginalConstraint = getEffectiveStringValue(TYPE_PREFIX + "marginal-constraint");
-        marginalsDefsFileUrl = getEffectiveStringValue(TYPE_PREFIX + "marginals-defs-file-url");
-        marginalsFileUrl = getEffectiveStringValue(TYPE_PREFIX + "marginals-file-url");
-        dataServiceUrl = getEffectiveStringValue(TYPE_PREFIX + "data-service-url");
     }
 
     private @NotNull

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ImproveSPOWithMarginalsModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/ImproveSPOWithMarginalsModule.java
@@ -381,7 +381,7 @@ public class ImproveSPOWithMarginalsModule extends AnnotatedAbstractModule {
 
     @Override
     public void loadManualConfiguration() {
-        super.loadConfiguration();
+        super.loadManualConfiguration();
     }
 
     private @NotNull

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/RetrieveGraphModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/RetrieveGraphModule.java
@@ -31,7 +31,7 @@ public class RetrieveGraphModule extends AnnotatedAbstractModule {
     private String endpointUrl;
 
     @Parameter(iri = TYPE_PREFIX + "page-size", comment = "Page size. Default is 10000.")
-    private Integer pageSize = DEFAULT_PAGE_SIZE;
+    private int pageSize = DEFAULT_PAGE_SIZE;
 
     public String getTypeURI() {
         return TYPE_URI;

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/RetrieveGraphModule.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/modules/RetrieveGraphModule.java
@@ -5,6 +5,8 @@ import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.engine.ExecutionContextFactory;
 import cz.cvut.spipes.impl.GraphChunkedDownload;
 import cz.cvut.spipes.modules.annotations.SPipesModule;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -12,6 +14,8 @@ import org.apache.jena.rdf.model.ModelFactory;
 
 // TODO - lable = SpEP retrieve graph
 @Slf4j
+@Getter
+@Setter
 @SPipesModule(label = "sparql endpoint retrieve graph", comment = "Retrieves graph from sparql endpoint specified by " +
         "?endpointUrl and optionaly ?namedGraphId. If ?namedGraphId is not specified it retreaves the default graph.")
 public class RetrieveGraphModule extends AnnotatedAbstractModule {
@@ -29,33 +33,8 @@ public class RetrieveGraphModule extends AnnotatedAbstractModule {
     @Parameter(iri = TYPE_PREFIX + "page-size", comment = "Page size. Default is 10000.")
     private Integer pageSize = DEFAULT_PAGE_SIZE;
 
-    public String getNamedGraphId() {
-        return namedGraphId;
-    }
-
-    public void setNamedGraphId(String namedGraphId) {
-        this.namedGraphId = namedGraphId;
-    }
-
     public String getTypeURI() {
         return TYPE_URI;
-    }
-
-    public String getEndpointUrl() {
-        return endpointUrl;
-    }
-
-    public void setEndpointUrl(String endpointUrl) {
-        this.endpointUrl = endpointUrl;
-    }
-
-    public int getPageSize() {
-        return pageSize;
-    }
-
-
-    public void setPageSize(int pageSize) {
-        this.pageSize = pageSize;
     }
 
     @Override

--- a/s-pipes-modules/module-tabular/src/main/java/cz/cvut/spipes/modules/TabularModule.java
+++ b/s-pipes-modules/module-tabular/src/main/java/cz/cvut/spipes/modules/TabularModule.java
@@ -96,7 +96,7 @@ import java.util.function.Supplier;
  * Does not support the <i>suppress output</i> annotation.
  */
 @SPipesModule(label = "Tabular module", comment = "Module for converting tabular data (e.g. CSV or TSV) to RDF")
-public class TabularModule extends AbstractModule {
+public class TabularModule extends AnnotatedAbstractModule {
 
     public static final String TYPE_URI = KBSS_MODULE.uri + "tabular";
     public static final String PARAM_URL_PREFIX = TYPE_URI + "/";
@@ -114,7 +114,7 @@ public class TabularModule extends AbstractModule {
     @Parameter(iri = SML.replace, comment = "Specifies whether a module should overwrite triples" +
         " from its predecessors. When set to true (default is false), it prevents" +
         " passing through triples from the predecessors.")
-    private boolean isReplace;
+    private boolean isReplace = false;
 
     @Parameter(iri = PARAM_URL_PREFIX + "source-resource-uri", comment = "URI of resource" +
         " that represent tabular data (e.g. resource representing CSV file).")
@@ -130,13 +130,14 @@ public class TabularModule extends AbstractModule {
     private String dataPrefix;
 
     @Parameter(iri = PARAM_URL_PREFIX + "skip-header", comment = "Skip header. Default is false.")
-    private boolean skipHeader;
+    private boolean skipHeader = false;
 
     //:process-table-at-index
     /**
      * Required parameter for HTML and EXCEL files that indicates that only specific single table should be processed
      */
-    private int processTableAtIndex;
+    @Parameter(iri = PARAM_URL_PREFIX + "process-table-at-index", comment = "Required parameter for HTML and EXCEL files that indicates that only specific single table should be processed")
+    private int processTableAtIndex = 0;
 
     // TODO - revise comment
     @Parameter(iri = PARAM_URL_PREFIX + "output-mode", comment = "Output mode. Default is standard-mode('http://onto.fel.cvut.cz/ontologies/lib/module/tabular/standard-mode)")
@@ -157,7 +158,7 @@ public class TabularModule extends AbstractModule {
     private ResourceFormat sourceResourceFormat = ResourceFormat.PLAIN;
 
     @Parameter(iri = PARAM_URL_PREFIX + "accept-invalid-quoting", comment = "Accept invalid quoting. Default is false.")
-    private boolean acceptInvalidQuoting;
+    private boolean acceptInvalidQuoting = false;
 
     /**
      * Represent a group of tables.
@@ -469,18 +470,12 @@ public class TabularModule extends AbstractModule {
     }
 
     @Override
-    public void loadConfiguration() {
+    public void loadManualConfiguration() {
         sourceResourceFormat = ResourceFormat.fromString(
             getPropertyValue(P_SOURCE_RESOURCE_FORMAT, ResourceFormat.PLAIN.getValue())
         );
         delimiter = getPropertyValue(P_DELIMITER, getDefaultDelimiterSupplier(sourceResourceFormat));
-        isReplace = getPropertyValue(SML.JENA.replace, false);
-        skipHeader = getPropertyValue(P_SKIP_HEADER, false);
-        processTableAtIndex = getPropertyValue(P_PROCESS_TABLE_AT_INDEX, 0);
-        acceptInvalidQuoting = getPropertyValue(P_ACCEPT_INVALID_QUOTING, false);
         quoteCharacter = getPropertyValue(P_QUOTE_CHARACTER, getDefaultQuoteCharacterSupplier(sourceResourceFormat));
-        dataPrefix = getEffectiveValue(P_DATE_PREFIX).asLiteral().toString();
-        sourceResource = getResourceByUri(getEffectiveValue(P_SOURCE_RESOURCE_URI).asLiteral().toString());
         outputMode = Mode.fromResource(
             getPropertyValue(P_OUTPUT_MODE, Mode.STANDARD.getResource())
         );

--- a/s-pipes-modules/module-tarql/src/main/java/cz/cvut/spipes/modules/ModuleTarql.java
+++ b/s-pipes-modules/module-tarql/src/main/java/cz/cvut/spipes/modules/ModuleTarql.java
@@ -18,7 +18,7 @@ import java.nio.file.Paths;
 @Slf4j
 @Deprecated //TODO merge with TarqlModule functionality
 @SPipesModule(label = "tarql-XXX-2", comment = "Module to convert CSV file to RDF and query it using SPRQL query. The module wraps org.deri.tarql.tarql. This module is depracated.")
-public class ModuleTarql extends AbstractModule {
+public class ModuleTarql extends AnnotatedAbstractModule {
 
     private static final String TYPE_URI = KBSS_MODULE.uri + "tarql" + "-XXX-2";
 
@@ -80,11 +80,4 @@ public class ModuleTarql extends AbstractModule {
         return TYPE_URI;
     }
 
-    @Override
-    public void loadConfiguration() {
-        inputFile = this.getStringPropertyValue(P_INPUT_FILE);
-        tarqlString = this.getStringPropertyValue(P_TARQL_STRING);
-        ontologyIRI = this.getStringPropertyValue(P_ONTOLOGY_IRI);
-//        noHeader = this.getPropertyValue(P_NO_HEADER, false);
-    }
 }

--- a/s-pipes-modules/module-tarql/src/main/java/cz/cvut/spipes/modules/TarqlModule.java
+++ b/s-pipes-modules/module-tarql/src/main/java/cz/cvut/spipes/modules/TarqlModule.java
@@ -142,22 +142,8 @@ public class TarqlModule extends AnnotatedAbstractModule {
         return KBSS_MODULE.uri + "tarql";
     }
 
-//    @Override
-//    public void loadConfiguration() {
-//        // TODO load default values from configuration
-//
-//        // TODO does not work with string query as object is not RDF resource ???
-//        constructQueries = resource
-//                .listProperties(SML.JENA.constructQuery)
-//                .toList().stream()
-//                .map(st -> st.getObject().asResource())
-//                .collect(Collectors.toList());
-//
-//        log.debug("Loaded {} spin construct queries.", constructQueries.size());
-//
-//        //TODO default value must be taken from template definition
-//        isReplace = this.getPropertyValue(SML.JENA.replace, false);
-//
-//        sourceFilePath = getEffectiveValue(SML.JENA.sourceFilePath).asLiteral().toString(); // TODO should be Path
-//    }
+    @Override
+    public void loadManualConfiguration() {
+        log.debug("Loaded {} spin construct queries.", constructQueries.size());
+    }
 }

--- a/s-pipes-modules/module-tarql/src/main/java/cz/cvut/spipes/modules/TarqlModule.java
+++ b/s-pipes-modules/module-tarql/src/main/java/cz/cvut/spipes/modules/TarqlModule.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @SPipesModule(label = "tarql", comment = "\"Runs one or more TARQL Construct queries on the input triples. The output RDF " +
         "will consist of the constructed triples and (unless sml:replace is true) the input triples.\"")
-public class TarqlModule extends AbstractModule {
+public class TarqlModule extends AnnotatedAbstractModule {
 
     //tarql [options] query.sparql [table.csv [...]]
 
@@ -45,7 +45,7 @@ public class TarqlModule extends AbstractModule {
     @Parameter(iri = SML.replace, comment = "If set to true, the output triples will only contain the " +
             "constructed triples. If no values or false are specified, the output will be the union of the input triples " +
             "and the constructed triples.")
-    private boolean isReplace;
+    private boolean isReplace = false;
 
     @Parameter(iri = SML.sourceFilePath, comment = "Source CSV file.")
     private String sourceFilePath;
@@ -142,26 +142,22 @@ public class TarqlModule extends AbstractModule {
         return KBSS_MODULE.uri + "tarql";
     }
 
-    @Override
-    public void loadConfiguration() {
-        // TODO load default values from configuration
-
-        // TODO does not work with string query as object is not RDF resource ???
-        constructQueries = resource
-                .listProperties(SML.JENA.constructQuery)
-                .toList().stream()
-                .map(st -> st.getObject().asResource())
-                .collect(Collectors.toList());
-
-        log.debug("Loaded {} spin construct queries.", constructQueries.size());
-
-        //TODO default value must be taken from template definition
-        isReplace = this.getPropertyValue(SML.JENA.replace, false);
-
-        sourceFilePath = getEffectiveValue(SML.JENA.sourceFilePath).asLiteral().toString(); // TODO should be Path
-    }
-
-
-
-
+//    @Override
+//    public void loadConfiguration() {
+//        // TODO load default values from configuration
+//
+//        // TODO does not work with string query as object is not RDF resource ???
+//        constructQueries = resource
+//                .listProperties(SML.JENA.constructQuery)
+//                .toList().stream()
+//                .map(st -> st.getObject().asResource())
+//                .collect(Collectors.toList());
+//
+//        log.debug("Loaded {} spin construct queries.", constructQueries.size());
+//
+//        //TODO default value must be taken from template definition
+//        isReplace = this.getPropertyValue(SML.JENA.replace, false);
+//
+//        sourceFilePath = getEffectiveValue(SML.JENA.sourceFilePath).asLiteral().toString(); // TODO should be Path
+//    }
 }

--- a/s-pipes-modules/module-text-analysis/src/main/java/cz/cvut/spipes/modules/TextAnalysisModule.java
+++ b/s-pipes-modules/module-text-analysis/src/main/java/cz/cvut/spipes/modules/TextAnalysisModule.java
@@ -187,11 +187,6 @@ public class TextAnalysisModule extends AnnotatedAbstractModule{
     }
 
     @Override
-    public void loadManualConfiguration() {
-        super.loadConfiguration();
-    }
-
-    @Override
     public String getTypeURI() {
         return TYPE_URI;
     }

--- a/s-pipes-modules/module-text-analysis/src/main/java/cz/cvut/spipes/modules/TextAnalysisModule.java
+++ b/s-pipes-modules/module-text-analysis/src/main/java/cz/cvut/spipes/modules/TextAnalysisModule.java
@@ -187,9 +187,8 @@ public class TextAnalysisModule extends AnnotatedAbstractModule{
     }
 
     @Override
-    public void loadConfiguration() {
+    public void loadManualConfiguration() {
         super.loadConfiguration();
-        selectQuery = getPropertyValue(SML.JENA.selectQuery).asResource().as(Select.class);
     }
 
     @Override


### PR DESCRIPTION
Resolves #274. 

I removed `loadConfiguration()` where possible in `s-pipes-modules`. However, there are three main reasons why I couldn't remove it from some other modules:

- 1) Field dependency on runtime values: Some fields depend on values retrieved from previous fields, which is why these values can only be defined at runtime.
 ```java
  @Override
    public void loadConfiguration() {
        e5xResourceUriStr = getEffectiveValue(KBSS_MODULE.JENA.has_resource_uri).asLiteral().toString();
        e5xResource = getResourceByUri(e5xResourceUriStr);
    }
```

- 2) Dependency on parent module configuration: Some modules invoke loadConfiguration() from parent modules.
```java
   @Override
    public void loadConfiguration() {
        super.loadConfiguration();
        marginalConstraint = getEffectiveStringValue(TYPE_PREFIX + "marginal-constraint");
        marginalsDefsFileUrl = getEffectiveStringValue(TYPE_PREFIX + "marginals-defs-file-url");
        marginalsFileUrl = getEffectiveStringValue(TYPE_PREFIX + "marginals-file-url");
        dataServiceUrl = getEffectiveStringValue(TYPE_PREFIX + "data-service-url");
    }
```
- 3) Conditional field initialization: Some fields with parameters need to be initialized only under certain conditions.
```java
    @Override
    public void loadConfiguration() {

        if (this.resource.getProperty(DescriptorModel.JENA.has_document_date) != null) { // TODO set current date if not specified
            documentDate = getEffectiveValue(DescriptorModel.JENA.has_document_date).asLiteral().toString();
        }

        if (this.resource.getProperty(DescriptorModel.JENA.has_rule_file) != null) { //TODO support more rule files
            ruleFilePaths.add(Paths.get(getEffectiveValue(DescriptorModel.JENA.has_rule_file).asLiteral().toString()));
        }
    }
```