### PR TITLE
 Github actions for dependbot skip to push image

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -12,6 +12,7 @@ env:
   MAIN_BRANCH_NAME: main
 jobs:
   build-and-publish:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Resolve #278 

@blcham 
Could you create an A/C for this issue? Is it sufficient to skip Dependabot activities?