### PR TITLE
Fix swagger can not execute behind proxy

### DIFF
--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -20,7 +20,7 @@ http {
 
         location /s-pipes-debug/ {
             proxy_pass http://s-pipes-engine-debug:8080/s-pipes-debug/;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
This PR solves the problem with Swagger-ui not adding the correct port to its requests and, therefore, not getting any responses.