### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>cz.cvut.kbss</groupId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
     <artifactId>s-pipes</artifactId>
     <packaging>pom</packaging>
     <name>SPipes (Semantic Pipelines)</name>

--- a/s-pipes-cli/pom.xml
+++ b/s-pipes-cli/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
 
     <name>SPipes Interface - Commandline</name>

--- a/s-pipes-cli/pom.xml
+++ b/s-pipes-cli/pom.xml
@@ -35,7 +35,6 @@
             <artifactId>s-pipes-modules-registry</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
-
         <!-- Commandline parameters processing -->
         <dependency>
             <groupId>args4j</groupId>

--- a/s-pipes-core/pom.xml
+++ b/s-pipes-core/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
 
     <name>SPipes Core</name>

--- a/s-pipes-debug/pom.xml
+++ b/s-pipes-debug/pom.xml
@@ -5,12 +5,12 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
 
-    <version>0.4.0</version>
+    <version>0.5.0</version>
     <artifactId>s-pipes-debug</artifactId>
     <description>Module for debugging of s-pipes</description>
     <name>SPipes Interface - Debug</name>

--- a/s-pipes-forms/pom.xml
+++ b/s-pipes-forms/pom.xml
@@ -6,7 +6,7 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-model/pom.xml
+++ b/s-pipes-model/pom.xml
@@ -9,12 +9,12 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
 
     <name>SPipes Model</name>
     <artifactId>s-pipes-model</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/s-pipes-modules-registry/pom.xml
+++ b/s-pipes-modules-registry/pom.xml
@@ -19,7 +19,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>cz.cvut.spipes.modules</groupId>
+            <groupId>cz.cvut.kbss</groupId>
             <artifactId>s-pipes-modules-text-analysis</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/s-pipes-modules-registry/pom.xml
+++ b/s-pipes-modules-registry/pom.xml
@@ -8,13 +8,13 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
 
     <artifactId>s-pipes-modules-registry</artifactId>
     <name>SPipes Modules Registry</name>
     <description>This module aggregates all available modules developed within the main project.</description>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/s-pipes-modules-utils/pom.xml
+++ b/s-pipes-modules-utils/pom.xml
@@ -6,7 +6,7 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules-utils/s-pipes-module-archetype/pom.xml
+++ b/s-pipes-modules-utils/s-pipes-module-archetype/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-modules-utils</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
 
     <name>SPipes Module Archetype</name>

--- a/s-pipes-modules-utils/s-pipes-module-creator-maven-plugin/pom.xml
+++ b/s-pipes-modules-utils/s-pipes-module-creator-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-modules-utils</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
 
     <name>SPipes Module Annotation Processor</name>

--- a/s-pipes-modules/module-ckan2rdf/pom.xml
+++ b/s-pipes-modules/module-ckan2rdf/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-dataset-discovery/pom.xml
+++ b/s-pipes-modules/module-dataset-discovery/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-eccairs/pom.xml
+++ b/s-pipes-modules/module-eccairs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-form/pom.xml
+++ b/s-pipes-modules/module-form/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-identity/pom.xml
+++ b/s-pipes-modules/module-identity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-nlp/pom.xml
+++ b/s-pipes-modules/module-nlp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,7 +21,7 @@
         <dependency> <!-- TODO extract to separate lib -->
             <groupId>cz.cvut.kbss</groupId>
             <artifactId>s-pipes-modules-sparql-endpoint</artifactId>
-            <version>0.4.0</version>
+            <version>0.5.0</version>
         </dependency>
         <!--<dependency>-->
             <!--<groupId>org.ocpsoft.prettytime</groupId>-->
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>cz.cvut.kbss</groupId>
             <artifactId>s-pipes-modules-rdf4j</artifactId>
-            <version>0.4.0</version>
+            <version>0.5.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/s-pipes-modules/module-rdf4j/pom.xml
+++ b/s-pipes-modules/module-rdf4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-rdfstream/pom.xml
+++ b/s-pipes-modules/module-rdfstream/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-modules</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <artifactId>s-pipes-modules-rdfstream</artifactId>
     <name>SPipes Modules - RDF Stream</name>

--- a/s-pipes-modules/module-security/pom.xml
+++ b/s-pipes-modules/module-security/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-sparql-endpoint/pom.xml
+++ b/s-pipes-modules/module-sparql-endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-tabular/pom.xml
+++ b/s-pipes-modules/module-tabular/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-tarql/pom.xml
+++ b/s-pipes-modules/module-tarql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-text-analysis/pom.xml
+++ b/s-pipes-modules/module-text-analysis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/pom.xml
+++ b/s-pipes-modules/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>s-pipes-parent</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
         <relativePath>../s-pipes-parent/pom.xml</relativePath>
     </parent>
 

--- a/s-pipes-parent/pom.xml
+++ b/s-pipes-parent/pom.xml
@@ -13,7 +13,7 @@
 
     <artifactId>s-pipes-parent</artifactId>
     <name>SPipes Parent</name>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/s-pipes-test/pom.xml
+++ b/s-pipes-test/pom.xml
@@ -6,7 +6,7 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-web/pom.xml
+++ b/s-pipes-web/pom.xml
@@ -8,12 +8,12 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </parent>
 
     <name>SPipes Interface - Web</name>
     <artifactId>s-pipes-web</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
     <packaging>war</packaging>
 
     <repositories>


### PR DESCRIPTION
@blcham 
Bump s-pipes version to 0.5.0

in s-pipes-modules-registry I had to change groupId for `s-pipes-modules-text-analysis` module
from cz.cvut.**spipes.modules** to cz.cvut.**kbss**

