### PR TITLE
Migrate to new shacl version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>cz.cvut.kbss</groupId>
-    <version>0.6.0</version>
+    <version>0.7.0</version>
     <artifactId>s-pipes</artifactId>
     <packaging>pom</packaging>
     <name>SPipes (Semantic Pipelines)</name>

--- a/s-pipes-cli/pom.xml
+++ b/s-pipes-cli/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <name>SPipes Interface - Commandline</name>

--- a/s-pipes-core/pom.xml
+++ b/s-pipes-core/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.topbraid</groupId>
             <artifactId>shacl</artifactId>
-            <version>1.0.1</version>
+            <version>1.4.4</version>
             <exclusions> <!-- TODO update jena libs and remove exclusions -->
                 <exclusion>
                     <groupId>org.apache.jena</groupId>
@@ -146,4 +146,15 @@
             </testResource>
         </testResources>
     </build>
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+        <repository>
+            <id>ossrh.releases</id>
+            <name>Sonatype Gateway to Maven Central</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </repositories>
 </project>

--- a/s-pipes-core/pom.xml
+++ b/s-pipes-core/pom.xml
@@ -146,15 +146,4 @@
             </testResource>
         </testResources>
     </build>
-    <repositories>
-        <repository>
-            <id>central</id>
-            <url>https://repo1.maven.org/maven2/</url>
-        </repository>
-        <repository>
-            <id>ossrh.releases</id>
-            <name>Sonatype Gateway to Maven Central</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </repositories>
 </project>

--- a/s-pipes-core/pom.xml
+++ b/s-pipes-core/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <name>SPipes Core</name>

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/engine/VariablesBinding.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/engine/VariablesBinding.java
@@ -6,8 +6,10 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.QuerySolutionMap;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.riot.Lang;
+import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
-import org.apache.jena.sparql.engine.binding.BindingUtils;
+import org.apache.jena.sparql.engine.binding.BindingBuilder;
+import org.apache.jena.sparql.engine.binding.BindingFactory;
 import org.apache.jena.vocabulary.RDF;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -61,7 +63,11 @@ public class VariablesBinding {
     }
 
     public Binding asBinding() {
-        return BindingUtils.asBinding(binding);
+        if(binding == null)
+            return BindingFactory.empty();
+        BindingBuilder bb = BindingBuilder.create();
+        binding.varNames().forEachRemaining(v -> bb.add(Var.alloc(v), binding.get(v).asNode()));
+        return bb.build();
     }
 
     public boolean isEmpty() {

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/manager/OntoDocManager.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/manager/OntoDocManager.java
@@ -394,7 +394,7 @@ public class OntoDocManager implements OntologyDocumentManager {
         public void handleFailedRead(String url, Model model, Exception e) {
 
             if (e instanceof HttpException) {
-                int responseCode = ((HttpException) e).getResponseCode();
+                int responseCode = ((HttpException) e).getStatusCode();
                 if (responseCode == 404) {
                     log.warn("Attempt to read ontology from {} returned HTTP code '404 - Not Found'.", url);
                     return;

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/util/JenaUtils.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/util/JenaUtils.java
@@ -195,24 +195,25 @@ public class JenaUtils {
             : model.read(is, null, FileUtils.langTurtle);
     }
 
-
+    // TODO - Deside if reified statements should be supported or replaced with something else, e.g. RDF-star. Based on
+    //  the decision retain or rewrite HOTFIX methods and their usage. Delete "HOTFIX" from comments.
     /**
      * HOTFIX - for model.listReifiedStatements()
      *
      * @param m
-     * @return iterator of resources which have the RDF.object property
+     * @return iterator of resources which have the RDF.subject, RDF.predicate and RDF.object properties
      */
     public static ExtendedIterator<Resource> listStatementSubjectOfReifiedStatements(Model m){
         return m.listResourcesWithProperty(RDF.object).filterKeep(r -> r.hasProperty(RDF.subject) && r.hasProperty(RDF.predicate));
     }
 
     /**
-     * HOTFIX - adding reified statement resource to model as statement
+     * HOTFIX - adding reified statement represented by <code>rs</code> resource to model as statement
      *
      * @param m
      * @return iterator of resources which have the RDF.object property
      */
-    public static void addStatement(Model m, org.apache.jena.rdf.model.Resource rs){
+    public static void addStatementRepresentedByResource(Model m, org.apache.jena.rdf.model.Resource rs){
         m.add(rs.getPropertyResourceValue(RDF.subject), rs.getPropertyResourceValue(RDF.predicate).as(Property.class), rs.getProperty(RDF.object).getObject());
     }
 
@@ -221,8 +222,8 @@ public class JenaUtils {
      * @param st
      * @return the resource representing the statement
      */
-    public static Resource createReifiedStatement(Statement st) {
-        return createReifiedStatement(st.getModel(),st);
+    public static Resource addReifiedStatement(Statement st) {
+        return addReifiedStatement(st.getModel(),st);
     }
 
     /**
@@ -230,7 +231,7 @@ public class JenaUtils {
      * @param st
      * @return the resource representing the statement
      */
-    public static Resource createReifiedStatement(Model m, Statement st) {
+    public static Resource addReifiedStatement(Model m, Statement st) {
 
         m.add(st);
 

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/util/JenaUtils.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/util/JenaUtils.java
@@ -3,14 +3,12 @@ package cz.cvut.spipes.util;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.compose.MultiUnion;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.*;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFWriter;
 import org.apache.jena.riot.RIOT;
 import org.apache.jena.util.FileUtils;
+import org.apache.jena.util.iterator.ExtendedIterator;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDF;
 import org.jetbrains.annotations.NotNull;
@@ -197,4 +195,51 @@ public class JenaUtils {
             : model.read(is, null, FileUtils.langTurtle);
     }
 
+
+    /**
+     * HOTFIX - for model.listReifiedStatements()
+     *
+     * @param m
+     * @return iterator of resources which have the RDF.object property
+     */
+    public static ExtendedIterator<Resource> listStatementSubjectOfReifiedStatements(Model m){
+        return m.listResourcesWithProperty(RDF.object).filterKeep(r -> r.hasProperty(RDF.subject) && r.hasProperty(RDF.predicate));
+    }
+
+    /**
+     * HOTFIX - adding reified statement resource to model as statement
+     *
+     * @param m
+     * @return iterator of resources which have the RDF.object property
+     */
+    public static void addStatement(Model m, org.apache.jena.rdf.model.Resource rs){
+        m.add(rs.getPropertyResourceValue(RDF.subject), rs.getPropertyResourceValue(RDF.predicate).as(Property.class), rs.getProperty(RDF.object).getObject());
+    }
+
+    /**
+     * HOTFIX - add the reified statement of <code>st</code> to the model to the <code>st</code>
+     * @param st
+     * @return the resource representing the statement
+     */
+    public static Resource createReifiedStatement(Statement st) {
+        return createReifiedStatement(st.getModel(),st);
+    }
+
+    /**
+     * HOTFIX - add the reified statement of <code>st</code> to the <code>m</code>.
+     * @param st
+     * @return the resource representing the statement
+     */
+    public static Resource createReifiedStatement(Model m, Statement st) {
+
+        m.add(st);
+
+        Resource stR = m.createResource();
+        stR
+                .addProperty(RDF.type, RDF.Statement)
+                .addProperty(RDF.subject, st.getSubject())
+                .addProperty(RDF.predicate, st.getPredicate())
+                .addProperty(RDF.object, st.getObject());
+        return stR;
+    }
 }

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/util/SPINUtils.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/util/SPINUtils.java
@@ -77,7 +77,7 @@ public class SPINUtils {
         return evaluate(constantOrExpression, Optional.ofNullable(context)
                 .map(ExecutionContext::getVariablesBinding)
                 .map(VariablesBinding::asBinding)
-                .orElse(BindingFactory.create()));
+                .orElse(BindingFactory.empty()));
     }
 
     public static RDFNode evaluate(RDFNode constantOrExpression, Binding bindings) {

--- a/s-pipes-core/src/main/java/cz/cvut/spipes/util/query/OneStepBackExtendedResultSet.java
+++ b/s-pipes-core/src/main/java/cz/cvut/spipes/util/query/OneStepBackExtendedResultSet.java
@@ -8,6 +8,7 @@ import org.apache.jena.sparql.engine.binding.Binding;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * ResultSet that extends the original result set by adding bindings from the previous query solution.
@@ -98,5 +99,15 @@ public class OneStepBackExtendedResultSet implements ResultSet  {
     @Override
     public Model getResourceModel() {
         return resultSet.getResourceModel();
+    }
+
+    @Override
+    public void forEachRemaining(Consumer<? super QuerySolution> action) {
+        resultSet.forEachRemaining(action);
+    }
+
+    @Override
+    public void close() {
+        resultSet.close();
     }
 }

--- a/s-pipes-core/src/test/java/cz/cvut/shacl/SHACLIntegrationTest.java
+++ b/s-pipes-core/src/test/java/cz/cvut/shacl/SHACLIntegrationTest.java
@@ -11,8 +11,12 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.sparql.core.Var;
-import org.apache.jena.sparql.engine.binding.BindingFactory;
-import org.apache.jena.sparql.engine.binding.BindingMap;
+import org.apache.jena.sparql.engine.binding.BindingBuilder;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.expr.NodeValue;
+import org.apache.jena.sparql.function.FunctionEnv;
+import org.apache.jena.sparql.function.FunctionEnvBase;
+import org.apache.jena.sparql.util.ExprUtils;
 import org.apache.jena.util.FileUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -88,13 +92,13 @@ public class SHACLIntegrationTest {
                 .next();
 
         // evaluate expression
-        BindingMap bindings = BindingFactory.create();
+        BindingBuilder bb = BindingBuilder.create();
         String repositoryUrl = "http://repository.org";
         String graphId = "http://graphid.org";
-        bindings.add(Var.alloc("sparqlEndpoint"), NodeFactory.createLiteral(repositoryUrl));
-        bindings.add(Var.alloc("defaultGraphUri"), NodeFactory.createLiteral(graphId));
+        bb.add(Var.alloc("sparqlEndpoint"), NodeFactory.createLiteralString(repositoryUrl));
+        bb.add(Var.alloc("defaultGraphUri"), NodeFactory.createLiteralString(graphId));
 
-        RDFNode nodeValue = SPINUtils.evaluate(call, bindings);
+        RDFNode nodeValue = SPINUtils.evaluate(call, bb.build());
 
         assertEquals(nodeValue.asNode().toString(), constructServiceUrl(repositoryUrl, graphId));
     }

--- a/s-pipes-debug/pom.xml
+++ b/s-pipes-debug/pom.xml
@@ -5,12 +5,12 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
 
-    <version>0.6.0</version>
+    <version>0.7.0</version>
     <artifactId>s-pipes-debug</artifactId>
     <description>Module for debugging of s-pipes</description>
     <name>SPipes Interface - Debug</name>

--- a/s-pipes-forms/pom.xml
+++ b/s-pipes-forms/pom.xml
@@ -6,7 +6,7 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-model/pom.xml
+++ b/s-pipes-model/pom.xml
@@ -9,12 +9,12 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <name>SPipes Model</name>
     <artifactId>s-pipes-model</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/s-pipes-modules-registry/pom.xml
+++ b/s-pipes-modules-registry/pom.xml
@@ -28,11 +28,11 @@
             <artifactId>s-pipes-modules-tabular</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
-        <dependency>
-            <groupId>cz.cvut.kbss</groupId>
-            <artifactId>s-pipes-modules-tarql</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>cz.cvut.kbss</groupId>-->
+<!--            <artifactId>s-pipes-modules-tarql</artifactId>-->
+<!--            <version>${project.parent.version}</version>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>cz.cvut.kbss</groupId>
             <artifactId>s-pipes-modules-identity</artifactId>

--- a/s-pipes-modules-registry/pom.xml
+++ b/s-pipes-modules-registry/pom.xml
@@ -8,13 +8,13 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <artifactId>s-pipes-modules-registry</artifactId>
     <name>SPipes Modules Registry</name>
     <description>This module aggregates all available modules developed within the main project.</description>
-    <version>0.6.0</version>
+    <version>0.7.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/s-pipes-modules-utils/pom.xml
+++ b/s-pipes-modules-utils/pom.xml
@@ -6,7 +6,7 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules-utils/s-pipes-module-archetype/pom.xml
+++ b/s-pipes-modules-utils/s-pipes-module-archetype/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-modules-utils</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <name>SPipes Module Archetype</name>

--- a/s-pipes-modules-utils/s-pipes-module-creator-maven-plugin/pom.xml
+++ b/s-pipes-modules-utils/s-pipes-module-creator-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-modules-utils</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <name>SPipes Module Annotation Processor</name>

--- a/s-pipes-modules/module-ckan2rdf/pom.xml
+++ b/s-pipes-modules/module-ckan2rdf/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-ckan2rdf/src/main/java/cz/cvut/spipes/modules/SparqlEndpointDatasetExplorerModule.java
+++ b/s-pipes-modules/module-ckan2rdf/src/main/java/cz/cvut/spipes/modules/SparqlEndpointDatasetExplorerModule.java
@@ -60,7 +60,7 @@ public class SparqlEndpointDatasetExplorerModule extends AnnotatedAbstractModule
                 Calendar.getInstance()));
 
 
-            // TODO - is timeout(propConnectionTimeout) proper replacement for setTimeout(propConnectionTimeout, propQueryTimeout)?
+            // TODO - check in git history that timeout(propConnectionTimeout) is proper replacement for previous call of setTimeout(propConnectionTimeout, propQueryTimeout)?
             QueryExecutionHTTPBuilder builder = QueryExecutionHTTP.service(propSparqlEndpointUrl);
 
             builder.query(strSparql.toString()).timeout(propConnectionTimeout);

--- a/s-pipes-modules/module-ckan2rdf/src/main/java/cz/cvut/spipes/modules/SparqlEndpointDatasetExplorerModule.java
+++ b/s-pipes-modules/module-ckan2rdf/src/main/java/cz/cvut/spipes/modules/SparqlEndpointDatasetExplorerModule.java
@@ -3,24 +3,21 @@ package cz.cvut.spipes.modules;
 import cz.cvut.spipes.constants.KBSS_MODULE;
 import cz.cvut.spipes.engine.ExecutionContext;
 import cz.cvut.spipes.engine.ExecutionContextFactory;
-
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.util.Calendar;
-
 import cz.cvut.spipes.modules.annotations.SPipesModule;
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.query.ParameterizedSparqlString;
-import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.exec.http.QueryExecutionHTTP;
+import org.apache.jena.sparql.exec.http.QueryExecutionHTTPBuilder;
 import org.apache.jena.vocabulary.RDF;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Calendar;
 
 @SPipesModule(label = "sparqlEndpointDatasetExplorer-v1", comment = "TODO")
 public class SparqlEndpointDatasetExplorerModule extends AnnotatedAbstractModule {
@@ -61,11 +58,13 @@ public class SparqlEndpointDatasetExplorerModule extends AnnotatedAbstractModule
             model.add(iAccess, pHasUrl, ResourceFactory.createResource(propSparqlEndpointUrl));
             model.add(iAccess, pHasTime, ResourceFactory.createTypedLiteral(
                 Calendar.getInstance()));
-            try {
-                final Query query = strSparql.asQuery();
-                final QueryExecution qexec =
-                    QueryExecutionFactory.sparqlService(propSparqlEndpointUrl, query);
-                qexec.setTimeout(propConnectionTimeout, propQueryTimeout);
+
+
+            // TODO - is timeout(propConnectionTimeout) proper replacement for setTimeout(propConnectionTimeout, propQueryTimeout)?
+            QueryExecutionHTTPBuilder builder = QueryExecutionHTTP.service(propSparqlEndpointUrl);
+
+            builder.query(strSparql.toString()).timeout(propConnectionTimeout);
+            try (final QueryExecution qexec = builder.build()) {
                 model.add(qexec.execConstruct());
             } catch (Exception e) {
                 model.add(iAccess,

--- a/s-pipes-modules/module-dataset-discovery/pom.xml
+++ b/s-pipes-modules/module-dataset-discovery/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-eccairs/pom.xml
+++ b/s-pipes-modules/module-eccairs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-form/pom.xml
+++ b/s-pipes-modules/module-form/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-identity/pom.xml
+++ b/s-pipes-modules/module-identity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-nlp/pom.xml
+++ b/s-pipes-modules/module-nlp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,7 +21,7 @@
         <dependency> <!-- TODO extract to separate lib -->
             <groupId>cz.cvut.kbss</groupId>
             <artifactId>s-pipes-modules-sparql-endpoint</artifactId>
-            <version>0.6.0</version>
+            <version>0.7.0</version>
         </dependency>
         <!--<dependency>-->
             <!--<groupId>org.ocpsoft.prettytime</groupId>-->
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>cz.cvut.kbss</groupId>
             <artifactId>s-pipes-modules-rdf4j</artifactId>
-            <version>0.6.0</version>
+            <version>0.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModule.java
+++ b/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModule.java
@@ -6,6 +6,7 @@ import cz.cvut.spipes.engine.ExecutionContextFactory;
 import cz.cvut.spipes.modules.annotations.SPipesModule;
 import cz.cvut.spipes.sutime.AnnforModel;
 import cz.cvut.spipes.sutime.DescriptorModel;
+import cz.cvut.spipes.util.JenaUtils;
 import edu.stanford.nlp.ling.CoreAnnotations;
 import edu.stanford.nlp.ling.CoreLabel;
 import edu.stanford.nlp.pipeline.*;
@@ -61,14 +62,14 @@ public class SUTimeModule extends AnnotatedAbstractModule {
         AnnotationPipeline pipeline = loadPipeline();
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-        List<ReifiedStatement> temporalAnnotationStmts = new LinkedList<>();
+        List<Resource> temporalAnnotationStmts = new LinkedList<>();
         m.listStatements()
             .filterDrop(st -> !st.getObject().isLiteral())
             .toList().forEach(
             st -> {
                 String objectStr = st.getObject().asLiteral().getLexicalForm();
 
-                ReifiedStatement reifiedSt = m.createReifiedStatement(st);
+                Resource reifiedSt = JenaUtils.createReifiedStatement(st);
                 try {
                     ArrayList<AnnforModel> singleStDates = temporalAnalysis(pipeline, objectStr);
                     for(AnnforModel s:singleStDates){

--- a/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModule.java
+++ b/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModule.java
@@ -23,11 +23,8 @@ import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.vocabulary.RDF;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 @Slf4j
 @SPipesModule(label = "temporal v0.1", comment = "Annotate temporal expressions in literals in input model.")
@@ -69,7 +66,7 @@ public class SUTimeModule extends AnnotatedAbstractModule {
             st -> {
                 String objectStr = st.getObject().asLiteral().getLexicalForm();
 
-                Resource reifiedSt = JenaUtils.createReifiedStatement(st);
+                Resource reifiedSt = JenaUtils.addReifiedStatement(st);
                 try {
                     ArrayList<AnnforModel> singleStDates = temporalAnalysis(pipeline, objectStr);
                     for(AnnforModel s:singleStDates){

--- a/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModuleNew.java
+++ b/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModuleNew.java
@@ -28,7 +28,6 @@ import cz.cvut.spipes.spin.vocabulary.SP;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
@@ -148,7 +147,7 @@ public class SUTimeModuleNew extends AnnotatedAbstractModule {
 
                         if (!singleStDates.isEmpty()) {
                             Model mm = ModelFactory.createDefaultModel();
-                            Resource reifiedSt = JenaUtils.createReifiedStatement(st);
+                            Resource reifiedSt = JenaUtils.addReifiedStatement(st);
 
                             for (AnnforModel s : singleStDates) {
 

--- a/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModuleNew.java
+++ b/s-pipes-modules/module-nlp/src/main/java/cz/cvut/spipes/modules/SUTimeModuleNew.java
@@ -136,7 +136,7 @@ public class SUTimeModuleNew extends AnnotatedAbstractModule {
 
         log.debug("Extracting temporal information from model of size {}", m.size());
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-        List<ReifiedStatement> temporalAnnotationStmts = new LinkedList<>();
+        List<Resource> temporalAnnotationStmts = new LinkedList<>();
         m.listStatements()
             .filterDrop(st -> !st.getObject().isLiteral())
             .forEachRemaining(
@@ -148,7 +148,7 @@ public class SUTimeModuleNew extends AnnotatedAbstractModule {
 
                         if (!singleStDates.isEmpty()) {
                             Model mm = ModelFactory.createDefaultModel();
-                            ReifiedStatement reifiedSt = mm.createReifiedStatement(st);
+                            Resource reifiedSt = JenaUtils.createReifiedStatement(st);
 
                             for (AnnforModel s : singleStDates) {
 

--- a/s-pipes-modules/module-nlp/src/test/java/cz/cvut/spipes/modules/SUTimeModuleIntegrationTest.java
+++ b/s-pipes-modules/module-nlp/src/test/java/cz/cvut/spipes/modules/SUTimeModuleIntegrationTest.java
@@ -3,6 +3,7 @@ package cz.cvut.spipes.modules;
 import cz.cvut.spipes.engine.ExecutionContextFactory;
 import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.sparql.exec.http.QueryExecutionHTTP;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +42,7 @@ public class SUTimeModuleIntegrationTest {
     private Model getModel(String endpointUrl, String namedGraphUri) {
         String query = "CONSTRUCT {?s ?p ?o } FROM { GRAPH <" + namedGraphUri + "> { ?s ?p ?o } }";
 
-        return QueryExecutionFactory.sparqlService(endpointUrl, query).execConstruct();
+        return QueryExecutionHTTP.service(endpointUrl, query).execConstruct();
     }
 
     private void deployTemporalExtraction(String inputEndpointUrl, String namedGraphUri, String outputSesameServerUrl, String outputRepositoryName) {

--- a/s-pipes-modules/module-rdf4j/pom.xml
+++ b/s-pipes-modules/module-rdf4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jDeployModule.java
+++ b/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jDeployModule.java
@@ -13,7 +13,6 @@ import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFLanguages;
-import org.apache.jena.vocabulary.RDF;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
@@ -34,7 +33,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 @SPipesModule(label = "deploy", comment =
@@ -213,7 +211,7 @@ public class Rdf4jDeployModule extends AnnotatedAbstractModule {
                     .mapWith( gs -> gs.getObject().toString())
                         .forEachRemaining(
                             u ->  {
-                                JenaUtils.addStatement(dataset.getNamedModel(u), rs);
+                                JenaUtils.addStatementRepresentedByResource(dataset.getNamedModel(u), rs);
                             }
                         );
             }

--- a/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jDeployModule.java
+++ b/s-pipes-modules/module-rdf4j/src/main/java/cz/cvut/spipes/modules/Rdf4jDeployModule.java
@@ -6,12 +6,14 @@ import cz.cvut.spipes.engine.ExecutionContextFactory;
 import cz.cvut.spipes.exception.ModuleConfigurationInconsistentException;
 import cz.cvut.spipes.modules.annotations.SPipesModule;
 import cz.cvut.spipes.util.CoreConfigProperies;
+import cz.cvut.spipes.util.JenaUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
-import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.*;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFLanguages;
+import org.apache.jena.vocabulary.RDF;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
@@ -32,6 +34,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 @SPipesModule(label = "deploy", comment =
@@ -204,13 +207,13 @@ public class Rdf4jDeployModule extends AnnotatedAbstractModule {
 
     static Dataset createDatasetFromAnnotatedModel(@NotNull Model model) {
         Dataset dataset = DatasetFactory.create();
-        model.listReifiedStatements().forEachRemaining(
+        JenaUtils.listStatementSubjectOfReifiedStatements(model).forEachRemaining(
             rs -> {
                 rs.listProperties(KBSS_MODULE.JENA.is_part_of_graph)
                     .mapWith( gs -> gs.getObject().toString())
                         .forEachRemaining(
                             u ->  {
-                                dataset.getNamedModel(u).add(rs.getStatement());
+                                JenaUtils.addStatement(dataset.getNamedModel(u), rs);
                             }
                         );
             }

--- a/s-pipes-modules/module-rdfstream/pom.xml
+++ b/s-pipes-modules/module-rdfstream/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-modules</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <artifactId>s-pipes-modules-rdfstream</artifactId>
     <name>SPipes Modules - RDF Stream</name>

--- a/s-pipes-modules/module-rdfstream/src/main/java/cz/cvut/kbss/spipes/modules/JenaStreamRDFExperiment.java
+++ b/s-pipes-modules/module-rdfstream/src/main/java/cz/cvut/kbss/spipes/modules/JenaStreamRDFExperiment.java
@@ -74,14 +74,14 @@ public class JenaStreamRDFExperiment {
         final StreamRDF dest = StreamRDFLib.graph(m.getGraph()) ;
         try {
             System.out.println("mock parser: sending first triple");
-            dest.triple(new Triple(
+            dest.triple(Triple.create(
                     NodeFactory.createURI("http://ont.fel.cvut.cz/Person"),
                     NodeFactory.createURI("http://ont.fel.cvut.cz/birthDate"),
                     NodeFactory.createLiteralByValue(new Date(), XSDDatatype.XSDdate)));
 
             Thread.sleep(3000);
             System.out.println("mock parser: sending second triple");
-            dest.triple(new Triple(
+            dest.triple(Triple.create(
                     NodeFactory.createURI("http://ont.fel.cvut.cz/Person"),
                     NodeFactory.createURI("http://ont.fel.cvut.cz/name"),
                     NodeFactory.createLiteral("George", "en")));

--- a/s-pipes-modules/module-rdfstream/src/main/java/cz/cvut/kbss/spipes/modules/StreamRDFWithJena.java
+++ b/s-pipes-modules/module-rdfstream/src/main/java/cz/cvut/kbss/spipes/modules/StreamRDFWithJena.java
@@ -9,6 +9,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.impl.ModelCom;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFParser;
 import org.apache.jena.riot.system.StreamRDF;
 import org.apache.jena.riot.system.StreamRDFLib;
 
@@ -49,7 +50,7 @@ public class StreamRDFWithJena {
 //        StreamOps.
         InputStream is = new FileInputStream(inputFile);
         // parse the InputStream is an transform it to a streamRDF stream of triples/quads (in this case triples)
-        RDFDataMgr.parse(streamRDF, is, lang);
+        RDFParser.source(is).lang(lang).parse(streamRDF);
     }
 
     /**
@@ -73,7 +74,7 @@ public class StreamRDFWithJena {
 //        StreamOps.
         InputStream is = new FileInputStream(inputFile);
         // parse the InputStream is an transform it to a streamRDF stream of triples/quads (in this case triples)
-        RDFDataMgr.parse(streamRDF, is, lang);
+        RDFParser.source(is).lang(lang).parse(streamRDF);
     }
     
     public static class CountURISink extends SinkNull<Triple> {

--- a/s-pipes-modules/module-security/pom.xml
+++ b/s-pipes-modules/module-security/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-sparql-endpoint/pom.xml
+++ b/s-pipes-modules/module-sparql-endpoint/pom.xml
@@ -21,7 +21,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
-            <artifactId>jena-tdb</artifactId>
+            <artifactId>jena-tdb1</artifactId>
             <version>${org.apache.jena}</version>
         </dependency>
 

--- a/s-pipes-modules/module-sparql-endpoint/pom.xml
+++ b/s-pipes-modules/module-sparql-endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/impl/GraphChunkedDownload.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/impl/GraphChunkedDownload.java
@@ -1,8 +1,8 @@
 package cz.cvut.spipes.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.sparql.exec.http.QueryExecutionHTTP;
 
 
 @Slf4j
@@ -57,7 +57,10 @@ public abstract class GraphChunkedDownload {
      * @return
      */
     protected Model executeQuery(String query) {
-        return QueryExecutionFactory.sparqlService(endpointUrl, query).execConstruct();
+        // According to docs QueryExecutionHTTP is AutoCloseable and models from returned construct are valid after close
+        try(QueryExecutionHTTP qe = QueryExecutionHTTP.service(endpointUrl, query)) {
+            return qe.execConstruct();
+        }
     }
 
     public String getNamedGraphId() {

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/tdb/TDBModelHelper.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/tdb/TDBModelHelper.java
@@ -1,7 +1,7 @@
 package cz.cvut.spipes.tdb;
 
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.tdb.store.GraphTDB;
+import org.apache.jena.tdb1.store.GraphTDB;
 
 class TDBModelHelper {
 

--- a/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/tdb/TDBTempFactory.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/main/java/cz/cvut/spipes/tdb/TDBTempFactory.java
@@ -16,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.tdb.TDBFactory;
+import org.apache.jena.tdb1.TDB1Factory;
 
 @Slf4j
 public class TDBTempFactory {
@@ -28,7 +28,7 @@ public class TDBTempFactory {
         finalizePhantomModels();
         Path tempDir = getTempDir();
         log.debug("Creating temporary TDB dataset at directory {}.", tempDir);
-        Dataset ds = TDBFactory.createDataset(tempDir.toString());
+        Dataset ds = TDB1Factory.createDataset(tempDir.toString());
         Model outModel = ds.getNamedModel(getRandomModelUri());
         setUpFinalization(outModel);
         return ds.getNamedModel(getRandomModelUri());

--- a/s-pipes-modules/module-sparql-endpoint/src/test/java/cz/cvut/spipes/tdb/TDBTempFactoryTest.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/test/java/cz/cvut/spipes/tdb/TDBTempFactoryTest.java
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.tdb.store.GraphTDB;
+import org.apache.jena.tdb1.store.GraphTDB;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/s-pipes-modules/module-sparql-endpoint/src/test/java/cz/cvut/spipes/utils/EndpointTestUtils.java
+++ b/s-pipes-modules/module-sparql-endpoint/src/test/java/cz/cvut/spipes/utils/EndpointTestUtils.java
@@ -1,15 +1,17 @@
 package cz.cvut.spipes.utils;
 
-import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.query.ResultSet;
+import org.apache.jena.sparql.exec.http.QueryExecutionHTTP;
 
 public class EndpointTestUtils {
 
 
     public static long getNumberOfTriples(String sparqlEndpointUrl, String namedGraphUri) {
         String query = "SELECT (COUNT(*) as ?count) WHERE { GRAPH <" + namedGraphUri + "> { ?s ?p ?o }}";
-        ResultSet rs = QueryExecutionFactory.sparqlService(sparqlEndpointUrl, query).execSelect();
-        return Long.parseLong(rs.next().get("count").asLiteral().getString());
+        try(QueryExecutionHTTP qe = QueryExecutionHTTP.service(sparqlEndpointUrl, query)) {
+            ResultSet rs = qe.execSelect();
+            return Long.parseLong(rs.next().get("count").asLiteral().getString());
+        }
     }
 
 }

--- a/s-pipes-modules/module-tabular/pom.xml
+++ b/s-pipes-modules/module-tabular/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/module-tarql/src/main/java/cz/cvut/spipes/modules/TarqlModule.java
+++ b/s-pipes-modules/module-tarql/src/main/java/cz/cvut/spipes/modules/TarqlModule.java
@@ -10,7 +10,6 @@ import cz.cvut.spipes.registry.StreamResource;
 import cz.cvut.spipes.registry.StreamResourceRegistry;
 import cz.cvut.spipes.util.QueryUtils;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.jena.ext.com.google.common.io.Files;
 import org.apache.jena.query.Query;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -21,10 +20,11 @@ import cz.cvut.spipes.spin.model.Construct;
 
 import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
-import java.util.stream.Collectors;
 
 // TODO merge with ModuleTarql functionality
 @Slf4j
@@ -78,7 +78,7 @@ public class TarqlModule extends AnnotatedAbstractModule {
 
             try {
                 File tabularDataFile = File.createTempFile("output", ".tabular.txt");
-                Files.write(res.getContent(), tabularDataFile);
+                Files.write(tabularDataFile.toPath(), res.getContent());
                 tabularDataFilePath = tabularDataFile.getAbsolutePath();
             } catch (IOException e) {
                 throw new RuntimeException("Could not write tabular data stream to temporary file: {}", e);
@@ -100,8 +100,7 @@ public class TarqlModule extends AnnotatedAbstractModule {
                 final File queryFile = File.createTempFile("query", ".tarql");
                 final String queryString = query.toString();
                 //final String queryString = query.toString().replaceAll("\\?__FN__", "\"" + ontologyIRI + "\"");
-                Files.append(query.toString(), queryFile, Charset.defaultCharset());
-                //java.nio.file.Files.write(Paths.get(queryFile.toURI()), queryString.getBytes());
+                Files.writeString(queryFile.toPath(), query.toString(), Charset.defaultCharset(), StandardOpenOption.APPEND );
 
                 // execute tarql query.sparql table.csv
                 final File outputFile = File.createTempFile("output", ".ttl");

--- a/s-pipes-modules/module-text-analysis/pom.xml
+++ b/s-pipes-modules/module-text-analysis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>s-pipes-modules</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-modules/pom.xml
+++ b/s-pipes-modules/pom.xml
@@ -26,7 +26,7 @@
         <module>module-security</module>
         <module>module-sparql-endpoint</module>
         <module>module-tabular</module>
-        <module>module-tarql</module>
+<!--        <module>module-tarql</module>-->
         <module>module-text-analysis</module>
     </modules>
 

--- a/s-pipes-modules/pom.xml
+++ b/s-pipes-modules/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>s-pipes-parent</artifactId>
         <groupId>cz.cvut.kbss</groupId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
         <relativePath>../s-pipes-parent/pom.xml</relativePath>
     </parent>
 

--- a/s-pipes-parent/pom.xml
+++ b/s-pipes-parent/pom.xml
@@ -13,7 +13,7 @@
 
     <artifactId>s-pipes-parent</artifactId>
     <name>SPipes Parent</name>
-    <version>0.6.0</version>
+    <version>0.7.0</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/s-pipes-parent/pom.xml
+++ b/s-pipes-parent/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>17</jdk.version>
-        <org.apache.jena>3.17.0</org.apache.jena>
+        <org.apache.jena>5.2.0</org.apache.jena>
         <org.springframework.security.version>6.2.8</org.springframework.security.version>
         <org.springframework.boot.version>3.4.2</org.springframework.boot.version>
         <!-- Should be in sync with Spring Boot version -->
@@ -96,6 +96,11 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
+                <version>4.5.13</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient-cache</artifactId>
                 <version>4.5.13</version>
             </dependency>
             <dependency>

--- a/s-pipes-test/pom.xml
+++ b/s-pipes-test/pom.xml
@@ -6,7 +6,7 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/s-pipes-web/pom.xml
+++ b/s-pipes-web/pom.xml
@@ -45,6 +45,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient-cache</artifactId>
+        </dependency>
 
         <!-- SPipes core -->
         <dependency>

--- a/s-pipes-web/pom.xml
+++ b/s-pipes-web/pom.xml
@@ -8,12 +8,12 @@
         <relativePath>../s-pipes-parent</relativePath>
         <groupId>cz.cvut.kbss</groupId>
         <artifactId>s-pipes-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <name>SPipes Interface - Web</name>
     <artifactId>s-pipes-web</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0</version>
     <packaging>war</packaging>
 
     <repositories>

--- a/s-pipes-web/src/main/java/cz/cvut/spipes/rest/handler/ErrorValidationResponse.java
+++ b/s-pipes-web/src/main/java/cz/cvut/spipes/rest/handler/ErrorValidationResponse.java
@@ -44,7 +44,7 @@ public class ErrorValidationResponse {
 
         // Convert the model to expanded JSON-LD (otherwise framing does not work)
         StringWriter compactWriter = new StringWriter();
-        RDFDataMgr.write(compactWriter, getModel(), RDFFormat.JSONLD_EXPAND_FLAT);
+        RDFDataMgr.write(compactWriter, getModel(), RDFFormat.JSONLD_FLAT);
         String expandedJsonLD = compactWriter.toString();
         Object expandedJsonObject = JsonUtils.fromString(expandedJsonLD);
 

--- a/s-pipes-web/src/main/java/cz/cvut/spipes/util/RDFMimeType.java
+++ b/s-pipes-web/src/main/java/cz/cvut/spipes/util/RDFMimeType.java
@@ -10,7 +10,7 @@ public class RDFMimeType {
     public static final String LD_JSON_STRING = "application/ld+json";
 
     public static MediaType transform(Lang contentType) {
-        return MediaType.parseMediaType(contentType.getContentType().getContentType());
+        return MediaType.parseMediaType(contentType.getContentType().getContentTypeStr());
     }
 //    TODO ?
 //    text/trig


### PR DESCRIPTION
Resolves partially https://github.com/kbss-cvut/s-pipes/issues/44, https://github.com/kbss-cvut/s-pipes/issues/376, https://github.com/kbss-cvut/s-pipes/issues/184

This PR migrates shacl 1.0.1 --> 1.4.4 and jena 3.17.0 --> 5.2.0

Should be merged in `development` after `jopa-major-upgrade` is merged in `development`.

There some points that should be checked/verified:
- I could not find a way to refactor this expression `QueryExecution.setTimeout(propConnectionTimeout, propQueryTimeout);`. The closest alternative is `QueryExecutionHTTPBuilder.query(strSparql.toString()).timeout(propConnectionTimeout);`. 
- tarql module excluded from project - tarql dependency is incompatible with new jena version. 
- Is it ok to use RDFFormat.JSONLD_FLAT instead of RDFFormat.JSONLD_EXPAND_FLAT in ErrorValidationResponse.java - RDFFormat.JSONLD_EXPAND_FLAT is no longer available in jena 5.2.0. Tests pass.

Some other notable changes:
- Statement reification is no longer supported in new jena version. Alternative limited implementation of reified statements is implemented in JenaUtils and replaced with usage of reified statement api. New version of jena supports [RDF-star](https://jena.apache.org/documentation/rdf-star/) which has alternative for reified triples:
  `<< :john foaf:name "John Smith" >> dct:source <http://example/directory> .`
- `httpclient-cache` in `s-pipes-web` dependency added to avoid `ClassNotFoundException`.
