### PR TITLE
Remove sail-spin due to version conflicts

### DIFF
--- a/s-pipes-modules/module-ckan2rdf/pom.xml
+++ b/s-pipes-modules/module-ckan2rdf/pom.xml
@@ -25,11 +25,6 @@ If we need constraint validation we can try using SHACL ( org.eclipse.rdf4j-rdf4
             <artifactId>rdf4j-repository-sail</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.rdf4j</groupId>
-            <artifactId>rdf4j-sail-spin</artifactId>
-            <version>3.7.3</version>
-        </dependency>
-        <dependency>
             <groupId>eu.trentorise.opendata</groupId>
             <artifactId>jackan</artifactId>
             <version>0.4.3.1-JOPA-SNAPSHOT</version>

--- a/s-pipes-modules/module-ckan2rdf/pom.xml
+++ b/s-pipes-modules/module-ckan2rdf/pom.xml
@@ -18,12 +18,20 @@
             <groupId>cz.cvut.kbss</groupId>
             <artifactId>s-pipes-core</artifactId>
         </dependency>
-<!-- Do we need spin sail? I do not see where it is used?
-If we need constraint validation we can try using SHACL ( org.eclipse.rdf4j-rdf4j-shacl-5.0.3) instead of SPIN, see https://rdf4j.org/documentation/programming/spin/ -->
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-repository-sail</artifactId>
         </dependency>
+        <!--
+        Do we need spin sail? I do not see where it is used?
+        If we need constraint validation we can try using SHACL ( org.eclipse.rdf4j-rdf4j-shacl-5.0.3) instead of SPIN, see https://rdf4j.org/documentation/programming/spin/
+        Commented out for now since it uses Jena 3.7.3, which is outdated and causes version conflicts with JOPA.
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-sail-spin</artifactId>
+            <version>3.7.3</version>
+        </dependency>
+        -->
         <dependency>
             <groupId>eu.trentorise.opendata</groupId>
             <artifactId>jackan</artifactId>


### PR DESCRIPTION
Sail Spin uses an older version of Eclipse (and does not have the newer one), which causes version conflicts and exceptions like this:

> Handler dispatch failed: java.lang.NoSuchMethodError: &#39;void org.eclipse.rdf4j.common.iteration.IterationWrapper.&lt;init&gt;(org.eclipse.rdf4j.common.iteration.CloseableIteration)&#39;</p><p><b>Description</b> The server encountered an unexpected condition that prevented it from fulfilling the request.</p><p><b>Exception</b></p><pre>jakarta.servlet.ServletException: Handler dispatch failed: java.lang.NoSuchMethodError: &#39;void org.eclipse.rdf4j.common.iteration.IterationWrapper.&lt;init&gt;(org.eclipse.rdf4j.common.iteration.CloseableIteration)&#39;

When I'm trying to execute functions from s-pipes-editor